### PR TITLE
Separate downloads fragments into their own temp dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Your `yt-dlp` config should include the following options for optimal working co
 ```json
 {
     "windowsfilenames": true,
-    "continue_dl": true,
     "live_from_start": true,
     "format_sort": [
         "codec:avc:m4a"


### PR DESCRIPTION
This changes fixes the following problems:
- [x] Remove any temp files left over from downloads.
- [x] Prevent live stream downloads that was downloading before it went offline from preventing the re-download of the VOD.

However, sadly this change breaks `continue_dl` yt-dlp option. We think it's acceptable trade off.