### PR TITLE
Video Streaming imporvements.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,7 @@
         "YTP_DOWNLOAD_PATH": "${workspaceFolder}/var/downloads",
         "YTP_TEMP_PATH": "${workspaceFolder}/var/tmp",
         "YTP_URL_HOST": "http://localhost:8081",
-        "YTP_LOG_LEVEL": "DEBUG"
+        "YTP_LOG_LEVEL": "DEBUG",
       }
     },
     {
@@ -48,7 +48,7 @@
         "YTP_DOWNLOAD_PATH": "${workspaceFolder}/var/downloads",
         "YTP_TEMP_PATH": "${workspaceFolder}/var/tmp",
         "YTP_URL_HOST": "http://localhost:8081",
-        "YTP_LOG_LEVEL": "DEBUG"
+        "YTP_LOG_LEVEL": "DEBUG",
       }
     },
     {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
     "preferredcodec",
     "preferredquality",
     "tmpfilename",
+    "vcodec",
     "vconvert",
     "writedescription",
     "xerror"

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,12 +34,8 @@ ENV YTP_PORT=8081
 ENV XDG_CONFIG_HOME=/config
 ENV XDG_CACHE_HOME=/tmp
 
-# removed ffmpeg as 6.1.0 is broken with DASH protocal downloads
-COPY --from=mwader/static-ffmpeg:6.1.1 /ffmpeg /usr/bin/
-COPY --from=mwader/static-ffmpeg:6.1.1 /ffprobe /usr/bin/
-
 RUN mkdir /config /downloads && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone && \
-  apk add --update --no-cache bash mkvtoolnix patch aria2 coreutils curl shadow sqlite tzdata libmagic && \
+  apk add --update --no-cache bash mkvtoolnix patch aria2 coreutils curl shadow sqlite tzdata libmagic ffmpeg && \
   useradd -u ${USER_ID:-1000} -U -d /app -s /bin/bash app && \
   rm -rf /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ Certain values can be set via environment variables, using the `-e` parameter on
 * __YTP_PORT__: Which port to bind to. Defaults to `8081`.
 * __YTP_LOG_LEVEL__: Log level. Defaults to `info`.
 * __YTP_MAX_WORKERS__: How many works to use for downloads. Defaults to `1`.
+* __YTP_MAX_WORKERS__: How many works to use for downloads. Defaults to `1`.
+* __YTP_STREAMER_VCODEC__: The video codec to use for in-browser streaming. Defaults to `libx264`.
+* __YTP_STREAMER_ACODEC__: The audio codec to use for in-browser streaming. Defaults to `aac`.
 
 ## Running behind a reverse proxy
 

--- a/app/Config.py
+++ b/app/Config.py
@@ -53,6 +53,9 @@ class Config:
 
     started: int = 0
 
+    streamer_vcodec = 'libx264'
+    streamer_acodec = 'aac'
+
     ytdlp_version: str = YTDLP_VERSION
 
     _int_vars: tuple = ('port', 'max_workers', 'socket_timeout', 'extract_info_timeout',)


### PR DESCRIPTION
- [x] Allow the user to changed the used codecs for video/audio using ENV vars.
- [x] Revert back to using the built-in ffmpeg as it's updated to 6.1.1+ bypassing the problem combining files.
- [x] Add Caching to segments responses to not waste resources re-encoding same segments.