### PR TITLE
allow adding format via ytdlp.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,6 +34,7 @@
         "YTP_TEMP_PATH": "${workspaceFolder}/var/tmp",
         "YTP_URL_HOST": "http://localhost:8081",
         "YTP_LOG_LEVEL": "DEBUG",
+        "YTP_DEBUG": "false",
       }
     },
     {

--- a/app/Config.py
+++ b/app/Config.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 import re
@@ -47,6 +46,8 @@ class Config:
 
     debug: bool = False
 
+    debugpy_port: int = 5678
+
     new_version_available: bool = False
 
     extract_info_timeout: int = 70
@@ -63,7 +64,7 @@ class Config:
 
     ytdlp_version: str = YTDLP_VERSION
 
-    _int_vars: tuple = ('port', 'max_workers', 'socket_timeout', 'extract_info_timeout',)
+    _int_vars: tuple = ('port', 'max_workers', 'socket_timeout', 'extract_info_timeout', 'debugpy_port',)
     _immutable: tuple = ('version', '__instance', 'ytdl_options', 'new_version_available', 'ytdlp_version', 'started')
     _boolean_vars: tuple = ('keep_archive', 'ytdl_debug', 'debug', 'temp_keep', 'allow_manifestless',)
 
@@ -147,10 +148,12 @@ class Config:
         if self.debug:
             try:
                 import debugpy
-                debugpy.listen(("0.0.0.0", 5678))
-                LOG.info("starting debugpy server on [0.0.0.0:5678]")
+                debugpy.listen(("0.0.0.0", self.debugpy_port))
+                LOG.info(f"starting debugpy server on [0.0.0.0:{self.debugpy_port}]")
             except ImportError:
                 LOG.error("debugpy not found, please install it with 'pip install debugpy'")
+            except Exception as e:
+                LOG.error(f"Error starting debugpy server at [0.0.0.0:{self.debugpy_port}]: {e}")
 
         optsFile: str = os.path.join(self.config_path, 'ytdlp.json')
         if os.path.exists(optsFile) and os.path.getsize(optsFile) > 0:

--- a/app/Download.py
+++ b/app/Download.py
@@ -11,7 +11,7 @@ from AsyncPool import Terminator
 from Utils import Notifier, get_format, get_opts, jsonCookie, mergeConfig
 from ItemDTO import ItemDTO
 from Config import Config
-
+from multiprocessing.managers import SyncManager
 LOG = logging.getLogger('download')
 
 
@@ -32,7 +32,7 @@ class Download:
     debug: bool = False
     tempPath: str = None
     notifier: Notifier = None
-    manager: multiprocessing.Manager = None
+    manager: SyncManager = None
     canceled: bool = False
     is_live: bool = False
     info_dict: dict = None
@@ -69,7 +69,7 @@ class Download:
         self.temp_dir = info.temp_dir
         self.output_template_chapter = info.output_template_chapter
         self.output_template = info.output_template
-        self.format = get_format(info.format, info.quality)
+        self.format = config.ytdl_options.get('format', get_format(info.format, info.quality))
         self.ytdl_opts = get_opts(info.format, info.quality, info.ytdlp_config if info.ytdlp_config else {})
         self.info = info
         self.id = info._id
@@ -159,7 +159,8 @@ class Download:
                     LOG.warning(
                         f'Live stream detected for [{self.info.title}], The following opts [{deletedOpts=}] have been deleted which are known to cause issues with live stream and post stream manifestless mode.')
 
-            LOG.info(f'Downloading {os.getpid()=} id="{self.info.id}" title="{self.info.title}".')
+            LOG.info(
+                f'Downloading {os.getpid()=} id="{self.info.id}" title="{self.info.title}" format="{self.format}" fq="{self.info.format}/{self.info.quality}".')
 
             cls = yt_dlp.YoutubeDL(params=params)
 

--- a/app/Webhooks.py
+++ b/app/Webhooks.py
@@ -49,6 +49,7 @@ class Webhooks:
         return await asyncio.gather(*tasks)
 
     async def __send(self, event: str, target: dict, item: ItemDTO) -> dict:
+        from Config import Config
         req: dict = target.get('request')
         try:
             LOG.info(f"Sending {event=} {item.id=} to [{target.get('name')}]")
@@ -83,7 +84,7 @@ class Webhooks:
                 }
 
                 msg = f"[{target.get('name')}] Response to [{event=} {item.id=}] [status: {response.status_code}]."
-                if respData.get('text'):
+                if Config.get_instance().debug and respData.get('text'):
                     msg += f" [Body: {respData.get('text','??')}]"
 
                 LOG.info(msg)

--- a/app/main.py
+++ b/app/main.py
@@ -161,6 +161,7 @@ class Main:
             **self.queue.get(),
             "config": self.config,
             "tasks": [],
+            "presets": [],
         }
 
         if os.path.exists(os.path.join(self.config.config_path, 'tasks.json')):


### PR DESCRIPTION
This release allow you to set default format via `ytdlp.json`, it will override user selection in the request.

This is a temporary fix and can be skipped via not setting default format key and it will restore old behavior.

My plan is to deprecate and remove the format/quality selection and instead use presets which can be extended via user supplied options in the request itself or via adding new `presets.json` file.

This change will come with the new version of the UI where we move to nuxtjs, using raw vuejs was fun at the start however, maintaining the dependencies proven to be a bit default task.    