### PR TITLE
Fix download audio only preset

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,17 +30,17 @@
       "console": "internalConsole",
       "justMyCode": true,
       "env": {
-        "PYDEVD_DISABLE_FILE_VALIDATION": "1",
         "YTP_CONFIG_PATH": "${workspaceFolder}/var/config",
         "YTP_DOWNLOAD_PATH": "${workspaceFolder}/var/downloads",
         "YTP_TEMP_PATH": "${workspaceFolder}/var/tmp",
+        "PYDEVD_DISABLE_FILE_VALIDATION": "1",
         "YTP_URL_HOST": "http://localhost:8081",
-        "YTP_LOG_LEVEL": "DEBUG",
-        "YTP_DEBUG": "true",
-        "YTP_YTDL_DEBUG": "true",
         "YTP_MAX_WORKERS": "2",
         "YTP_IGNORE_UI": "true",
         "YTP_PIP_IGNORE_UPDATES": "true",
+        "YTP_LOG_LEVEL": "DEBUG",
+        "YTP_DEBUG": "true",
+        "YTP_YTDL_DEBUG": "true",
       }
     },
     {

--- a/app/library/Download.py
+++ b/app/library/Download.py
@@ -164,6 +164,8 @@ class Download:
                 f'Downloading pid: {os.getpid()} id="{self.info.id}" title="{self.info.title}" preset="{self.preset}".'
             )
 
+            LOG.debug(f"Params before passing to yt-dlp: {params}")
+
             cls = yt_dlp.YoutubeDL(params=params)
 
             if isinstance(self.info_dict, dict) and len(self.info_dict) > 1:

--- a/app/library/DownloadQueue.py
+++ b/app/library/DownloadQueue.py
@@ -15,7 +15,7 @@ from .DataStore import DataStore
 from .Download import Download
 from .Emitter import Emitter
 from .ItemDTO import ItemDTO
-from .Utils import ExtractInfo, calcDownloadPath, isDownloaded, mergeConfig
+from .Utils import ExtractInfo, get_opts, calcDownloadPath, isDownloaded, mergeConfig
 
 LOG = logging.getLogger("DownloadQueue")
 TYPE_DONE: str = "done"
@@ -264,7 +264,7 @@ class DownloadQueue:
                 fut=asyncio.get_running_loop().run_in_executor(
                     None,
                     ExtractInfo,
-                    mergeConfig(self.config.ytdl_options, ytdlp_config),
+                    get_opts(preset, mergeConfig(self.config.ytdl_options, ytdlp_config)),
                     url,
                     bool(self.config.ytdl_debug),
                 ),

--- a/app/library/Utils.py
+++ b/app/library/Utils.py
@@ -122,13 +122,16 @@ def ExtractInfo(config: dict, url: str, debug: bool = False) -> dict:
         **config,
     }
 
-    # Remove keys that are not needed for info extraction as those keys generate files when used with extract_info.
-    for key in (
+    # Remove keys that are not needed for info extraction.
+    keys: list = [
         "writeinfojson",
         "writethumbnail",
         "writedescription",
         "writeautomaticsub",
-    ):
+        "postprocessors",
+    ]
+
+    for key in keys:
         if key in params:
             params.pop(key)
 

--- a/app/library/ffprobe.py
+++ b/app/library/ffprobe.py
@@ -82,7 +82,13 @@ class FFStream:
         """
         Is the stream labelled as a video stream.
         """
-        return self.__dict__.get("codec_type", None) == "video"
+        if self.__dict__.get("codec_type", None) != "video":
+            return False
+
+        if self.__dict__.get("codec_name", None) in ["png", "mjpeg", "gif", "bmp", "tiff", "webp"]:
+            return False
+
+        return True
 
     def is_subtitle(self):
         """

--- a/ui/components/VideoPlayer.vue
+++ b/ui/components/VideoPlayer.vue
@@ -18,7 +18,7 @@
 
 <template>
   <div>
-    <video ref="video" :poster="previewImageLink" :controls="isControls" :title="title" playsinline>
+    <video ref="video" :data-poster="thumbnail" :controls="isControls" :title="title" playsinline>
       <source :src="link" type="application/x-mpegURL" />
     </video>
   </div>
@@ -31,10 +31,6 @@ import Plyr from 'plyr'
 import 'plyr/dist/plyr.css'
 
 const props = defineProps({
-  previewImageLink: {
-    type: String,
-    default: ''
-  },
   link: {
     type: String,
     default: ''
@@ -109,7 +105,7 @@ const prepareVideoPlayer = () => {
     mediaMetadata['artist'] = props.artist
   }
 
-  player = new Plyr(video.value, {
+  let opts = {
     debug: false,
     clickToPlay: true,
     keyboard: { focused: true, global: true },
@@ -125,12 +121,28 @@ const prepareVideoPlayer = () => {
       enabled: true,
       key: 'plyr'
     },
+    poster: props.thumbnail,
+    artist: props.artist,
     title: props.title,
     mediaMetadata: mediaMetadata,
     captions: {
       update: true,
     }
-  });
+  };
+
+  if (props.artist) {
+    opts.artist = props.artist
+  }
+
+  if (props.title) {
+    opts.title = props.title
+  }
+
+  if (props.thumbnail) {
+    opts.poster = props.thumbnail
+  }
+
+  player = new Plyr(video.value, opts);
 
   hls = new Hls({
     debug: false,


### PR DESCRIPTION
Trying to download audio only from yt-dlp fails due to us caching the extract_info before adding format option.