### PR TITLE
remove debug statement

### DIFF
--- a/app/library/HttpAPI.py
+++ b/app/library/HttpAPI.py
@@ -289,7 +289,6 @@ class HttpAPI(Common):
                     try:
                         data = decrypt_data(auth_cookie, key=Config.get_instance().secret_key)
                         if data is not None:
-                            LOG.info(f"Decoded cookie data '{data}'.")
                             data = base64.b64encode(data.encode()).decode()
                             auth_header = f"Basic {data}"
                     except Exception as e:


### PR DESCRIPTION
This pull request includes a change to the logging behavior in the `middleware_handler` function within the `HttpAPI.py` file. The change removes an informational log statement that decoded cookie data.

Logging changes:

* [`app/library/HttpAPI.py`](diffhunk://#diff-b9296f201ccb63e0b417d76b4cc77ff90217e462e83409b25e53fd9123d7197aL292): Removed the log statement that printed decoded cookie data in the `middleware_handler` function.