### PR TITLE
Made it possible to not use format in preset

### DIFF
--- a/app/library/YTDLPOpts.py
+++ b/app/library/YTDLPOpts.py
@@ -82,7 +82,8 @@ class YTDLPOpts(metaclass=Singleton):
 
             self._preset_opts["cookiefile"] = str(file)
 
-        self._preset_opts["format"] = preset.format
+        if preset.format:
+            self._preset_opts["format"] = preset.format
 
         if preset.template:
             self._preset_opts["outtmpl"] = {"default": preset.template, "chapter": self._config.output_template_chapter}

--- a/app/library/YTDLPOpts.py
+++ b/app/library/YTDLPOpts.py
@@ -82,8 +82,7 @@ class YTDLPOpts(metaclass=Singleton):
 
             self._preset_opts["cookiefile"] = str(file)
 
-        if preset.format:
-            self._preset_opts["format"] = preset.format
+        self._preset_opts["format"] = preset.format
 
         if preset.template:
             self._preset_opts["outtmpl"] = {"default": preset.template, "chapter": self._config.output_template_chapter}
@@ -128,5 +127,8 @@ class YTDLPOpts(metaclass=Singleton):
         if not keep:
             self.presets_opts = {}
             self._item_opts = {}
+
+        if "format" in data and "not_set" == data["format"]:
+            data["format"] = None
 
         return data

--- a/ui/components/PresetForm.vue
+++ b/ui/components/PresetForm.vue
@@ -111,7 +111,8 @@
                     <span class="icon"><i class="fa-solid fa-info" /></span>
                     <span>The yt-dlp <code>[--format, -f]</code> video format code. see <NuxtLink
                         href="https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#format-selection" target="blank">this
-                        url</NuxtLink> for more info.</span>
+                        url</NuxtLink> for more info.</span>. Note, as this key is required, you can set the value to <code>not_set</code>
+                        to use the default yt-dlp format.
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
This pull request includes changes to improve the handling and documentation of the `format` option in the `YTDLPOpts` class and its usage in the UI.

Changes to `YTDLPOpts` class:

* [`app/library/YTDLPOpts.py`](diffhunk://#diff-d37158910547c723c86db10bbe69656921077f8e2af5e0ff1822e78305e12e39L85): Removed an unnecessary conditional check for `preset.format` in the `preset` method, ensuring the `format` option is always set if present.
* [`app/library/YTDLPOpts.py`](diffhunk://#diff-d37158910547c723c86db10bbe69656921077f8e2af5e0ff1822e78305e12e39R131-R133): Added logic in the `get_all` method to handle the case where the `format` value is `"not_set"`, converting it to `None` to use the default yt-dlp format.

Changes to UI:

* [`ui/components/PresetForm.vue`](diffhunk://#diff-017f6ead2e5c7495ba81ba253a366566b4bd2ef97b669be4c97b1600d7f513b7L114-R115): Updated the documentation for the `format` option to inform users that they can set the value to `"not_set"` to use the default yt-dlp format.