### PR TITLE
Added indicator in the WebUI for when post-processing are running

### DIFF
--- a/app/library/Download.py
+++ b/app/library/Download.py
@@ -100,6 +100,8 @@ class Download:
 
     def _postprocessor_hook(self, data: dict):
         if "MoveFiles" != data.get("postprocessor") or "finished" != data.get("status"):
+            dataDict = {k: v for k, v in data.items() if k in self._ytdlp_fields}
+            self.status_queue.put({"id": self.id, **dataDict, "status": "postprocessing"})
             return
 
         if self.debug:

--- a/app/library/Download.py
+++ b/app/library/Download.py
@@ -119,6 +119,7 @@ class Download:
             params = (
                 YTDLPOpts.get_instance()
                 .preset(self.preset)
+                .add({"break_on_existing": True})
                 .add(self.ytdl_opts, from_user=True)
                 .add(
                     {
@@ -132,7 +133,6 @@ class Download:
                             "chapter": self.template_chapter,
                         },
                         "noprogress": True,
-                        "break_on_existing": True,
                         "ignoreerrors": False,
                     },
                     from_user=False,

--- a/app/library/DownloadQueue.py
+++ b/app/library/DownloadQueue.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import json
 import logging
 import os
@@ -422,7 +423,15 @@ class DownloadQueue(metaclass=Singleton):
 
             entry = await asyncio.wait_for(
                 fut=asyncio.get_running_loop().run_in_executor(
-                    None, extract_info, yt_conf, url, bool(self.config.ytdl_debug)
+                    None,
+                    functools.partial(
+                        extract_info,
+                        config=yt_conf,
+                        url=url,
+                        debug=bool(self.config.ytdl_debug),
+                        no_archive=False,
+                        follow_redirect=True,
+                    ),
                 ),
                 timeout=self.config.extract_info_timeout,
             )

--- a/ui/components/Queue.vue
+++ b/ui/components/Queue.vue
@@ -191,6 +191,10 @@ const setIcon = item => {
     return 'fa-solid fa-circle-check';
   }
 
+  if ('postprocessing' === item.status) {
+    return 'fa-solid fa-cog fa-spin';
+  }
+
   if (null === item.status && true === config.paused) {
     return 'fa-solid fa-pause-circle';
   }
@@ -237,6 +241,10 @@ const updateProgress = (item) => {
 
   if (null === item.status && true === config.paused) {
     return 'Paused';
+  }
+
+  if ('postprocessing' === item.status) {
+    return 'Post-processors are running.';
   }
 
   if ('preparing' === item.status) {


### PR DESCRIPTION
This pull request includes several changes to the `Download` and `DownloadQueue` classes to improve functionality and error handling, as well as updates to the user interface to better reflect the current status of downloads. The most important changes are listed below:

### Enhancements to `Download` class:

* Added a dictionary comprehension to filter `data` items based on `_ytdlp_fields` and updated the `status_queue` with the filtered data and a status of "postprocessing" in the `_postprocessor_hook` method.
* Modified the `_download` method to add the `break_on_existing` option earlier in the process, ensuring it is set correctly. [[1]](diffhunk://#diff-c371d628747ee6d313fb7688dc2663db08508b0504ab438c6e8937957bd9bb30R122) [[2]](diffhunk://#diff-c371d628747ee6d313fb7688dc2663db08508b0504ab438c6e8937957bd9bb30L133)

### Enhancements to `DownloadQueue` class:

* Imported `functools` to use `functools.partial` for better readability and maintainability of the `add` method. [[1]](diffhunk://#diff-e8b7a658e21d8cfe8751ded76ca6956d5061004872c1a3d23b1238cc50387572R2) [[2]](diffhunk://#diff-e8b7a658e21d8cfe8751ded76ca6956d5061004872c1a3d23b1238cc50387572L425-R434)

### User interface updates:

* Updated the `setIcon` function in `Queue.vue` to return a spinning cog icon when the item status is "postprocessing".
* Updated the `updateProgress` function in `Queue.vue` to display "Post-processors are running." when the item status is "postprocessing".