### PR TITLE
restore opacity if the video is playing.

### DIFF
--- a/ui/components/History.vue
+++ b/ui/components/History.vue
@@ -275,6 +275,9 @@ const video_item = ref(null)
 const playVideo = item => video_item.value = item
 const closeVideo = () => video_item.value = null
 
+const bg_enable = useStorage('random_bg', true)
+const bg_opacity = useStorage('random_bg_opacity', 0.85)
+
 watch(masterSelectAll, (value) => {
   for (const key in stateStore.history) {
     const element = stateStore.history[key]
@@ -493,4 +496,11 @@ const reQueueItem = item => {
 }
 
 const pImg = e => e.target.naturalHeight > e.target.naturalWidth ? e.target.classList.add('image-portrait') : null
+watch(video_item, v => {
+  if (!bg_enable.value) {
+    return
+  }
+
+  document.querySelector('body').setAttribute("style", `opacity: ${ v ? 1 : bg_opacity.value}`)
+})
 </script>

--- a/ui/components/Queue.vue
+++ b/ui/components/Queue.vue
@@ -167,6 +167,9 @@ const showQueue = useStorage('showQueue', true)
 const hideThumbnail = useStorage('hideThumbnailQueue', false)
 const embed_url = ref('')
 
+const bg_enable = useStorage('random_bg', true)
+const bg_opacity = useStorage('random_bg_opacity', 0.85)
+
 watch(masterSelectAll, (value) => {
   for (const key in stateStore.queue) {
     const element = stateStore.queue[key];
@@ -337,4 +340,11 @@ const cancelItems = item => {
 }
 
 const pImg = e => e.target.naturalHeight > e.target.naturalWidth ? e.target.classList.add('image-portrait') : null
+watch(embed_url, v => {
+  if (!bg_enable.value) {
+    return
+  }
+  document.querySelector('body').setAttribute("style", `opacity: ${ v ? 1 : bg_opacity.value}`)
+})
+
 </script>


### PR DESCRIPTION
This pull request introduces changes to the background settings and their behavior in the `History.vue` and `Queue.vue` components. The main updates include adding new background-related settings and ensuring these settings affect the UI elements correctly when certain conditions are met.

Background settings:

* [`ui/components/History.vue`](diffhunk://#diff-d1b0dda75167c1b70eda106d79e4dd55d4bf589f0d1e04925120d8dbb388ad71R278-R280): Added `bg_enable` and `bg_opacity` settings to control background behavior and opacity. These settings are watched, and the body's opacity is adjusted based on the `video_item` value. [[1]](diffhunk://#diff-d1b0dda75167c1b70eda106d79e4dd55d4bf589f0d1e04925120d8dbb388ad71R278-R280) [[2]](diffhunk://#diff-d1b0dda75167c1b70eda106d79e4dd55d4bf589f0d1e04925120d8dbb388ad71R499-R505)

* [`ui/components/Queue.vue`](diffhunk://#diff-9c98365b3e09f32cf57fd5b70d4d69f9e9fbf4c1245f1b9ea855fb233f0cf942R170-R172): Added `bg_enable` and `bg_opacity` settings to control background behavior and opacity. These settings are watched, and the body's opacity is adjusted based on the `embed_url` value. [[1]](diffhunk://#diff-9c98365b3e09f32cf57fd5b70d4d69f9e9fbf4c1245f1b9ea855fb233f0cf942R170-R172) [[2]](diffhunk://#diff-9c98365b3e09f32cf57fd5b70d4d69f9e9fbf4c1245f1b9ea855fb233f0cf942R343-R349)