### PR TITLE
deprecate JSON yt-dlp config, and encourage cli options.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,11 +19,16 @@
     "attl",
     "autonumber",
     "changeslog",
+    "consoletitle",
+    "cookiesfrombrowser",
     "copyts",
     "daterange",
     "dotenv",
     "finaldir",
     "flac",
+    "forcejson",
+    "forceprint",
+    "fribidi",
     "getpid",
     "gpac",
     "httpx",
@@ -41,6 +46,7 @@
     "postprocessor",
     "preferredcodec",
     "preferredquality",
+    "printtraffic",
     "quicktime",
     "tmpfilename",
     "urandom",
@@ -56,7 +62,6 @@
     "en"
   ],
   "spellright.documentTypes": [
-    "latex",
-    "plaintext"
+    "latex"
   ],
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ ENV XDG_CONFIG_HOME=/config
 ENV XDG_CACHE_HOME=/tmp
 
 RUN mkdir /config /downloads && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone && \
-  apk add --update --no-cache bash mkvtoolnix patch aria2 coreutils curl shadow sqlite tzdata libmagic ffmpeg rtmpdump && \
+  apk add --update --no-cache bash mkvtoolnix patch aria2 coreutils curl shadow sqlite tzdata libmagic ffmpeg rtmpdump fribidi && \
   useradd -u ${USER_ID:-1000} -U -d /app -s /bin/bash app && \
   rm -rf /var/cache/apk/*
 

--- a/README.md
+++ b/README.md
@@ -25,22 +25,47 @@ Web GUI for [yt-dlp](https://github.com/yt-dlp/yt-dlp) with playlist & channel s
 * Support for curl_cffi, see [yt-dlp documentation](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#impersonation)
 * Support for both advanced and basic mode for WebUI.
 * Bundled tools in container: curl-cffi, ffmpeg, ffprobe, aria2, rtmpdump, mkvtoolsnix, mp4box.
-    
-# Recommended basic `ytdlp.json` file settings
 
-Your `/config/ytdlp.json` config should include the following basic options for optimal working conditions.
+# Breaking changes
 
-```json
-{
-  "windowsfilenames": true,
-  "continue_dl": true,
-  "live_from_start": true,
-  "format_sort": [ "codec:avc:m4a" ],
-}
-```
+Starting with versions tagged `*-20250330-*` I have deprecated the JSON yt-dlp config and all of it's related settings.
 
-> [!NOTE]
-> Note, the `format_sort`, forces YouTube to use x264 instead of vp9 codec, you can ignore it if you want. i prefer the media in x264.
+To be frank, it was pain to manage and hard for users to understand how to map cli options to json options. So, I have
+decided to just use the cli options directly. This means that you can now use the same options you would use in the command line
+directly in the WebUI, presets, and tasks.
+
+## `ytdlp.json` vs `ytdlp.cli`
+
+I have also added a new `ytdlp.cli` file that will be used to store the global options for yt-dlp. This file is located in the `/config` directory
+and will be used to store the global options for yt-dlp. This file is not required and presets can fill the gap for most of the
+use cases. But, if you want to use the same options for all your downloads, you can use this file to store the global options.
+
+So, if you have `ytdlp.cli` file it will take priority over the `ytdlp.json` file if both exists. As mitigation, I have implemented
+fallback to `ytdlp.json` file if `ytdlp.cli` file is not found. 
+
+## Presets
+
+I have deprecated the `JSON yt-dlp config` and `JSON yt-dlp Post-Processors` fields, and added new `Command arguments for yt-dlp`
+field to the presets. This field will be used to store the command line options for yt-dlp. I have also have added fallback, 
+if you have the `JSON yt-dlp config/Post-Processors` field set, the logic is, if `Command arguments for yt-dlp` is set
+it will take priority over the `JSON yt-dlp config/Post-Processors` field. If not set, it will fallback to the `JSON yt-dlp config/Post-Processors` field.
+
+If you are adding new presets, the deprecated fields will not show up anymore, they will only show up if actually have content in them 
+and editing old preset. So, Please migrate your presets to the new format.
+
+## Tasks
+
+I have also removed the `JSON yt-dlp config` and replaced it with `Command arguments for yt-dlp` field. Sadly, there is 
+no fallback, and once you upgrade to any version after `*-20250330-*` your `tasks.json` file will be updated to remove the
+`config` key. so, please make sure to backup your `tasks.json` file before upgrading.
+
+## closing statement
+
+I know it's a painful breaking change, but for the sake of maintainability and ease of use, I have decided to
+to make it happen sooner than later, the `JSON yt-dlp config`, was hard to manage and some features weren't really working 
+as expected, for example `--match-filter` and `--date` arguments etc. 
+
+So, Starting with `*-2025040*-*` tagged versions, the all the fallbacks and backwards compatibility will be removed.
 
 # Run using docker command
 
@@ -240,25 +265,19 @@ A Docker image can be built locally (it will build the UI too):
 docker build . -t ytptube
 ```
 
-# ytdlp.json file
+# ytdlp.cli file
 
-The `config/ytdlp.json`, is a json file which can be used to alter the default `yt-dlp` config settings globally. 
+The `config/ytdlp.cli`, is a command line options file for `yt-dlp` it will be globally applied to all downloads.
 
-We recommend not use this file for options that aren't **truly global**, everything that can be done via the `ytdlp.json` file
-can be done via a preset, which only effects the download that uses it. Example of good basic `ytdlp.json` file.
+We strongly recommend not use this file for options that aren't **truly global**, everything that can be done via the file
+can also be done via the presets which is dynamic can be altered per download. Example of good global options are to be 
+used for all downloads are:
 
-```json
-{
-  "windowsfilenames": true,
-  "continue_dl": true,
-  "live_from_start": true,
-  "format_sort": [ "codec:avc:m4a" ],
-}
+```bash
+--continue --windows-filenames --live-from-start
 ```
 
-Everything else can be done via the presets, and it's more flexible and easier to manage. You can convert your 
-own yt-dlp command arguments into a preset using the box found in the presets add page. For reference, The options can be found
-at [yt-dlp YoutubeDL.py](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/YoutubeDL.py#L214) file. And for the postprocessors at [yt-dlp postprocessor](https://github.com/yt-dlp/yt-dlp/tree/master/yt_dlp/postprocessor).
+Everything else can be done via the presets, and it's more flexible and easier to manage.
 
 # Authentication
 
@@ -275,7 +294,7 @@ What does the basic mode do? it hides the the following features from the WebUI.
 
 ### Header
 
-It disables everything except the `theme switcher` and `reload` button.
+It disables everything except the `settings button` and `reload` button.
 
 ### Add form 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Web GUI for [yt-dlp](https://github.com/yt-dlp/yt-dlp) with playlist & channel s
 * Can Handle live streams.
 * Scheduler to queue channels or playlists to be downloaded automatically at a specified time.
 * Send notification to targets based on selected events. 
-* Support per link `yt-dlp JSON config or cli options`, `cookies` & `output format`.
+* Support per link `cli options` & `cookies`
 * Queue multiple URLs separated by comma.
 * Simple file browser. `Disabled by default`
 * A built in video player that can play any video file regardless of the format. **With support for sidecar external subtitles**.

--- a/app/library/Download.py
+++ b/app/library/Download.py
@@ -114,8 +114,6 @@ class Download:
     def _progress_hook(self, data: dict):
         dataDict = {k: v for k, v in data.items() if k in self._ytdlp_fields}
 
-        LOG.debug("Status: %s", data)
-
         if "finished" == data.get("status") and data.get("info_dict", {}).get("filename", None):
             dataDict["filename"] = data["info_dict"]["filename"]
 
@@ -136,6 +134,12 @@ class Download:
             filename = data["info_dict"]["filepath"]
 
         self.status_queue.put({"id": self.id, "status": "finished", "filename": filename})
+
+    def post_hooks(self, filename: str | None = None):
+        if not filename:
+            return
+
+        self.status_queue.put({"id": self.id, "filename": filename})
 
     def _download(self):
         try:
@@ -180,6 +184,7 @@ class Download:
                 {
                     "progress_hooks": [self._progress_hook],
                     "postprocessor_hooks": [self._postprocessor_hook],
+                    "post_hooks": [self.post_hooks],
                 }
             )
 

--- a/app/library/Download.py
+++ b/app/library/Download.py
@@ -215,7 +215,7 @@ class Download:
                 f'Task id="{self.info.id}" PID="{os.getpid()}" title="{self.info.title}" preset="{self.preset}" started.'
             )
 
-            self.logger.debug("Params before passing to yt-dlp.", extra=params)
+            self.logger.debug(f"Params before passing to yt-dlp. {params}")
 
             params["logger"] = NestedLogger(self.logger)
 

--- a/app/library/Download.py
+++ b/app/library/Download.py
@@ -114,6 +114,8 @@ class Download:
     def _progress_hook(self, data: dict):
         dataDict = {k: v for k, v in data.items() if k in self._ytdlp_fields}
 
+        LOG.debug("Status: %s", data)
+
         if "finished" == data.get("status") and data.get("info_dict", {}).get("filename", None):
             dataDict["filename"] = data["info_dict"]["filename"]
 

--- a/app/library/Events.py
+++ b/app/library/Events.py
@@ -90,7 +90,6 @@ class Events:
     LOG_SUCCESS = "log_success"
 
     INITIAL_DATA = "initial_data"
-    YTDLP_CONVERT = "ytdlp_convert"
     ITEM_DELETE = "item_delete"
     ITEM_CANCEL = "item_cancel"
     STATUS = "status"

--- a/app/library/HttpAPI.py
+++ b/app/library/HttpAPI.py
@@ -473,10 +473,9 @@ class HttpAPI(Common):
         except Exception as e:
             err = str(e).strip()
             err = err.split("\n")[-1] if "\n" in err else err
-            LOG.error(f"Failed to convert args. '{err}'.")
-            LOG.exception(e)
+            err = err.replace("main.py: error: ", "").strip().capitalize()
             return web.json_response(
-                data={"error": f"Failed to convert args. '{err}'."}, status=web.HTTPBadRequest.status_code
+                data={"error": f"Failed to command line arguments for yt-dlp. '{err}'."}, status=web.HTTPBadRequest.status_code
             )
 
     @route("GET", "api/yt-dlp/url/info")

--- a/app/library/HttpAPI.py
+++ b/app/library/HttpAPI.py
@@ -872,14 +872,11 @@ class HttpAPI(Common):
             if not item.get("timer", None) or str(item.get("timer")).strip() == "":
                 item["timer"] = f"{random.randint(1,59)} */1 * * *"  # noqa: S311
 
-            if not item.get("cookies", None):
-                item["cookies"] = ""
-
-            if not item.get("config", None) or str(item.get("config")).strip() == "":
-                item["config"] = {}
-
             if not item.get("template", None):
                 item["template"] = ""
+
+            if not item.get("cli", None):
+                item["cli"] = ""
 
             try:
                 ins.validate(item)

--- a/app/library/HttpAPI.py
+++ b/app/library/HttpAPI.py
@@ -453,6 +453,9 @@ class HttpAPI(Common):
             if "paths" in data and "home" in data["paths"]:
                 response["download_path"] = data["paths"]["home"]
 
+            if "format" in data:
+                response["format"] = data["format"]
+
             for key in data:
                 if key in IGNORED_KEYS:
                     continue

--- a/app/library/HttpSocket.py
+++ b/app/library/HttpSocket.py
@@ -18,7 +18,7 @@ from .DownloadQueue import DownloadQueue
 from .encoder import Encoder
 from .Events import Event, EventBus, Events, error
 from .Presets import Presets
-from .Utils import arg_converter, is_downloaded
+from .Utils import is_downloaded
 
 LOG = logging.getLogger("socket_api")
 
@@ -285,25 +285,3 @@ class HttpSocket(Common):
     async def resume(self, *_, **__):
         self.queue.resume()
         await self._notify.emit(Events.PAUSED, data={"paused": False, "at": time.time()})
-
-    @ws_event
-    async def ytdlp_convert(self, sid: str, data: dict):
-        if not isinstance(data, dict) or "args" not in data:
-            await self._notify.emit(Events.ERROR, data=error("Invalid request or no options were given."), to=sid)
-            return
-
-        args: str | None = data.get("args")
-
-        if not args:
-            await self._notify.emit(Events.ERROR, data=error("no options were given."), to=sid)
-            return
-
-        try:
-            await self._notify.emit(Events.YTDLP_CONVERT, data=arg_converter(args), to=sid)
-        except Exception as e:
-            err = str(e).strip()
-            err = err.split("\n")[-1] if "\n" in err else err
-            LOG.error(f"Failed to convert args. '{err}'.")
-            await self._notify.emit(Events.ERROR, data=error(f"Failed to convert options. '{err}'."), to=sid)
-
-        return

--- a/app/library/ItemDTO.py
+++ b/app/library/ItemDTO.py
@@ -27,7 +27,6 @@ class ItemDTO:
     temp_dir: str | None = None
     status: str | None = None
     cookies: str | None = None
-    config: dict = field(default_factory=dict)
     template: str | None = None
     template_chapter: str | None = None
     timestamp: float = field(default_factory=lambda: time.time_ns())
@@ -37,6 +36,7 @@ class ItemDTO:
     file_size: int | None = None
     options: dict = field(default_factory=dict)
     extras: dict = field(default_factory=dict)
+    cli: str = ""
 
     # yt-dlp injected fields.
     tmpfilename: str | None = None
@@ -49,12 +49,13 @@ class ItemDTO:
     speed: str | None = None
     eta: str | None = None
 
-    # DEPRECATED: These fields are deprecated and will be removed in the future.
+    # @Deprecated: These fields are deprecated and will be removed in the future.
     thumbnail: str | None = None
     ytdlp_cookies: str | None = None
     ytdlp_config: dict = field(default_factory=dict)
     output_template: str | None = None
     output_template_chapter: str | None = None
+    config: dict = field(default_factory=dict)
 
     def serialize(self) -> dict:
         deprecated: tuple = (
@@ -65,6 +66,7 @@ class ItemDTO:
             "ytdlp_config",
             "output_template",
             "output_template_chapter",
+            "config",
         )
 
         if self.thumbnail and "thumbnail" not in self.extras:

--- a/app/library/Presets.py
+++ b/app/library/Presets.py
@@ -41,6 +41,9 @@ class Preset:
     cookies: str = ""
     """The default cookies to use if non is given."""
 
+    cli: str = ""
+    """yt-dlp cli command line arguments."""
+
     default: bool = False
 
     def serialize(self) -> dict:
@@ -219,6 +222,15 @@ class Presets(metaclass=Singleton):
         if preset.get("postprocessors") and not isinstance(preset.get("postprocessors"), list):
             msg = "Invalid postprocessors type. expected list."
             raise ValueError(msg)
+
+        if preset.get("cli"):
+            try:
+                from .Utils import arg_converter
+
+                arg_converter(args=preset.get("cli"))
+            except Exception as e:
+                msg = f"Invalid cli options. '{e!s}'."
+                raise ValueError(msg) from e
 
         return True
 

--- a/app/library/Tasks.py
+++ b/app/library/Tasks.py
@@ -10,8 +10,6 @@ from typing import Any
 import httpx
 from aiohttp import web
 
-from app.library.Utils import arg_converter
-
 from .config import Config
 from .encoder import Encoder
 from .Events import EventBus, Events, error, info, success
@@ -224,6 +222,7 @@ class Tasks(metaclass=Singleton):
 
         if task.get("cli"):
             try:
+                from .Utils import arg_converter
                 arg_converter(args=task.get("cli"))
             except Exception as e:
                 msg = f"Invalid cli options. '{e!s}'."

--- a/app/library/Utils.py
+++ b/app/library/Utils.py
@@ -434,12 +434,13 @@ def validate_url(url: str) -> bool:
     return True
 
 
-def arg_converter(args: str) -> dict:
+def arg_converter(args: str, remove_options: bool = False) -> dict:
     """
     Convert yt-dlp options to a dictionary.
 
     Args:
         args (str): yt-dlp options string.
+        remove_options (bool): Remove default options.
 
     Returns:
         dict: yt-dlp options dictionary.
@@ -471,6 +472,14 @@ def arg_converter(args: str) -> dict:
         matchFilter = inspect.getclosurevars(diff["match_filter"].func).nonlocals["filters"]
         if isinstance(matchFilter, set):
             diff["match_filter"] = {"filters": list(matchFilter)}
+
+    if remove_options:
+        for key in diff.copy():
+            if key in IGNORED_KEYS:
+                diff.pop(key, None)
+
+    if "_warnings" in diff:
+        diff.pop("_warnings", None)
 
     from .encoder import Encoder
 

--- a/app/library/YTDLPOpts.py
+++ b/app/library/YTDLPOpts.py
@@ -118,6 +118,7 @@ class YTDLPOpts(metaclass=Singleton):
                 "temp": self._config.temp_path,
             }
 
+        # @Deprecated - To be removed in future versions.
         if not preset.cli:
             if preset.postprocessors and isinstance(preset.postprocessors, list) and len(preset.postprocessors) > 0:
                 self._preset_opts["postprocessors"] = preset.postprocessors
@@ -165,6 +166,7 @@ class YTDLPOpts(metaclass=Singleton):
         if "format" in data and data["format"] in ["not_set", "default"]:
             data["format"] = None
 
+        # @Deprecated - To be removed in future versions, All the checks below this line are deprecated.
         if "daterange" in data and isinstance(data["daterange"], dict):
             from yt_dlp.utils import DateRange
 

--- a/app/library/common.py
+++ b/app/library/common.py
@@ -4,6 +4,7 @@ import logging
 from .config import Config
 from .DownloadQueue import DownloadQueue
 from .encoder import Encoder
+from .Utils import arg_converter
 
 LOG = logging.getLogger("common")
 
@@ -92,6 +93,14 @@ class Common:
                 config = json.loads(config)
             except Exception as e:
                 msg = f"Failed to parse json yt-dlp config for '{url}'. {e!s}"
+                raise ValueError(msg) from e
+
+        cli = item.get("cli")
+        if cli and len(cli) > 1:
+            try:
+                config = arg_converter(args=cli, remove_options=True)
+            except Exception as e:
+                msg = f"Failed to parse yt-dlp cli options. {e!s}"
                 raise ValueError(msg) from e
 
         return {

--- a/app/library/common.py
+++ b/app/library/common.py
@@ -28,7 +28,16 @@ class Common:
         self.default_preset = config.default_preset
 
     async def add(
-        self, url: str, preset: str, folder: str, cookies: str, config: dict, template: str, extras: dict | None = None
+        self,
+        url: str,
+        preset: str,
+        folder: str,
+        cookies: str,
+        # @deprecated: config: dict,
+        config: dict,
+        template: str,
+        extras: dict | None = None,
+        cli: str = "",
     ) -> dict[str, str]:
         """
         Add an item to the download queue.
@@ -41,6 +50,7 @@ class Common:
             config (dict): The yt-dlp config to be used for the download.
             template (str): The template to be used for the download.
             extras (dict): Extra data to be added to the download
+            cli (str): The yt-dlp cli options to be used for the download.
 
         Returns:
             dict[str, str]: The status of the download.
@@ -57,6 +67,7 @@ class Common:
             cookies=cookies,
             config=config if isinstance(config, dict) else {},
             template=template,
+            cli=cli,
             extras=extras,
         )
 
@@ -96,13 +107,14 @@ class Common:
                 raise ValueError(msg) from e
 
         cli = item.get("cli")
-        if cli and len(cli) > 1:
+        if cli and len(cli) > 2:
             try:
                 removed_options = []
-                config = arg_converter(args=cli, level=True, removed_options=removed_options)
+                arg_converter(args=cli, level=True, removed_options=removed_options)
                 if len(removed_options) > 0:
                     LOG.warning("Removed the following options '%s'.", ", ".join(removed_options))
 
+                config = {}
             except Exception as e:
                 msg = f"Failed to parse yt-dlp cli options. {e!s}"
                 raise ValueError(msg) from e
@@ -114,5 +126,6 @@ class Common:
             "cookies": cookies,
             "config": config if isinstance(config, dict) else {},
             "template": template,
+            "cli": cli if isinstance(cli, str) else "",
             "extras": extras if isinstance(extras, dict) else {},
         }

--- a/app/library/common.py
+++ b/app/library/common.py
@@ -98,7 +98,11 @@ class Common:
         cli = item.get("cli")
         if cli and len(cli) > 1:
             try:
-                config = arg_converter(args=cli, remove_options=True)
+                removed_options = []
+                config = arg_converter(args=cli, level=True, removed_options=removed_options)
+                if len(removed_options) > 0:
+                    LOG.warning("Removed the following options '%s'.", ", ".join(removed_options))
+
             except Exception as e:
                 msg = f"Failed to parse yt-dlp cli options. {e!s}"
                 raise ValueError(msg) from e

--- a/app/library/config.py
+++ b/app/library/config.py
@@ -12,7 +12,7 @@ import coloredlogs
 from dotenv import load_dotenv
 from yt_dlp.version import __version__ as YTDLP_VERSION
 
-from .Utils import IGNORED_KEYS, load_file, merge_dict
+from .Utils import REMOVE_KEYS, arg_converter, load_file, merge_dict
 from .version import APP_VERSION
 
 
@@ -218,7 +218,7 @@ class Config:
         "instance_title",
         "sentry_dsn",
         "console_enabled",
-        "browser_enabled"
+        "browser_enabled",
     )
     "The variables that are relevant to the frontend."
 
@@ -321,8 +321,38 @@ class Config:
             except Exception as e:
                 LOG.error(f"Error starting debugpy server at '0.0.0.0:{self.debugpy_port}'. {e}")
 
+        ytdlp_cli: str = os.path.join(self.config_path, "ytdlp.cli")
         optsFile: str = os.path.join(self.config_path, "ytdlp.json")
-        if os.path.exists(optsFile) and os.path.getsize(optsFile) > 5:
+        if os.path.exists(ytdlp_cli) and os.path.getsize(ytdlp_cli) > 2:
+            LOG.info(f"Loading yt-dlp custom options from '{ytdlp_cli}'.")
+            with open(ytdlp_cli) as f:
+                ytdlp_cli_opts = f.read().strip()
+                if ytdlp_cli_opts:
+                    try:
+                        removed_options = []
+                        self.ytdl_options = arg_converter(
+                            args=ytdlp_cli_opts,
+                            level=True,
+                            removed_options=removed_options,
+                        )
+
+                        try:
+                            LOG.debug("Parsed yt-dlp cli options '%s'.", self.ytdl_options)
+                        except Exception:
+                            pass
+
+                        if len(removed_options) > 0:
+                            LOG.warning(
+                                "Removed the following options: '%s' from '%s'", ", ".join(removed_options), ytdlp_cli
+                            )
+                    except Exception as e:
+                        msg = f"Failed to parse yt-dlp cli options from '{ytdlp_cli}'. '{e!s}'."
+                        raise ValueError(msg) from e
+                else:
+                    LOG.warning(f"Empty yt-dlp custom options file '{ytdlp_cli}'.")
+        # @Deprecated - To be removed in future versions.
+        elif os.path.exists(optsFile) and os.path.getsize(optsFile) > 5:
+            LOG.warning("The JSON ytdlp.json options file is deprecated, please use 'ytdlp.cli' file instead.")
             LOG.info(f"Loading yt-dlp custom options from '{optsFile}'.")
 
             (opts, status, error) = load_file(optsFile, dict)
@@ -330,16 +360,24 @@ class Config:
                 LOG.error(f"Could not load yt-dlp custom options from '{optsFile}'. {error}")
                 sys.exit(1)
             if isinstance(opts, dict):
-                for key in IGNORED_KEYS:
-                    if key in opts:
-                        LOG.error(f"Key '{key}' is not allowed to be loaded via 'ytdlp.json' file.")
-                        del opts[key]
+                bad_options = {k: v for d in REMOVE_KEYS for k, v in d.items()}
+                removed_options = []
+                for key in opts.copy():
+                    if key not in bad_options:
+                        continue
 
+                    removed_options.append(bad_options[key])
+                    opts.pop(key, None)
+
+                if len(removed_options) > 0:
+                    LOG.warning(
+                        "Removed the following options: '%s' from 'ytdlp.json' file.", ", ".join(removed_options)
+                    )
                 self.ytdl_options = merge_dict(self.ytdl_options, opts)
             else:
                 LOG.error(f"Invalid yt-dlp custom options file '{optsFile}'.")
         else:
-            LOG.info(f"No yt-dlp custom options found at '{optsFile}'.")
+            LOG.info(f"No yt-dlp custom options found at '{ytdlp_cli}'.")
 
         self.ytdl_options["socket_timeout"] = self.socket_timeout
 
@@ -373,7 +411,6 @@ class Config:
 
         key_file: str = os.path.join(self.config_path, "secret.key")
 
-        # save key as bytes.
         if os.path.exists(key_file) and os.path.getsize(key_file) > 5:
             with open(key_file, "rb") as f:
                 self.secret_key = f.read().strip()

--- a/app/library/config.py
+++ b/app/library/config.py
@@ -332,7 +332,7 @@ class Config:
                         removed_options = []
                         self.ytdl_options = arg_converter(
                             args=ytdlp_cli_opts,
-                            level=True,
+                            level=1,
                             removed_options=removed_options,
                         )
 

--- a/app/library/presets.json
+++ b/app/library/presets.json
@@ -6,6 +6,7 @@
     "folder": "",
     "template": "",
     "cookies": "",
+    "cli": "",
     "default": true
   },
   {
@@ -15,69 +16,37 @@
     "folder": "",
     "template": "",
     "cookies": "",
+    "cli": "",
     "default": true
   },
   {
     "id": "441675ed-b739-40f0-a0b0-1ecfcb9dc48b",
     "name": "1080p H264/m4a or best available",
     "format": "bv[height<=1080][ext=mp4]+ba[ext=m4a]/b[ext=mp4]/b[ext=webm]",
-    "args": {
-      "format_sort": [
-        "vcodec:h264"
-      ]
-    },
     "folder": "",
     "template": "",
     "cookies": "",
+    "cli": "-S vcodec:h264",
     "default": true
   },
   {
     "id": "9719fcc3-4cf2-4d88-b1e4-74dff3dba00e",
     "name": "720p h264/m4a or best available",
     "format": "bv[height<=720][ext=mp4]+ba[ext=m4a]/b[ext=mp4]/b[ext=webm]",
-    "args": {
-      "format_sort": [
-        "vcodec:h264"
-      ]
-    },
     "folder": "",
     "template": "",
     "cookies": "",
+    "cli": "-S vcodec:h264",
     "default": true
   },
   {
     "id": "a6fd4b25-2b3e-458d-bb57-b75e41cc4330",
     "name": "Audio only",
     "format": "bestaudio/best",
-    "args": {
-      "writethumbnail": true
-    },
-    "postprocessors": [
-      {
-        "key": "FFmpegExtractAudio",
-        "preferredcodec": "best",
-        "preferredquality": "5",
-        "nopostoverwrites": false
-      },
-      {
-        "key": "FFmpegMetadata",
-        "add_chapters": true,
-        "add_metadata": true,
-        "add_infojson": "if_exists"
-      },
-      {
-        "key": "EmbedThumbnail",
-        "already_have_thumbnail": false
-      },
-      {
-        "key": "FFmpegConcat",
-        "only_multi_video": true,
-        "when": "playlist"
-      }
-    ],
     "folder": "",
     "template": "",
     "cookies": "",
+    "cli": "--extract-audio --add-chapters --embed-metadata --embed-thumbnail",
     "default": true
   }
 ]

--- a/ui/components/History.vue
+++ b/ui/components/History.vue
@@ -141,17 +141,17 @@
                 </td>
                 <td class="is-vcentered is-items-center">
                   <div class="field is-grouped is-grouped-centered">
-                    <div class="control" v-if="'finished' === item.status || isEmbedable(item.url)">
-                      <button v-if="'finished' === item.status" @click="playVideo(item)" v-tooltip="'Play video'"
-                        class="button is-danger is-light is-small">
+                    <div class="control" v-if="('finished' === item.status && item.filename) || isEmbedable(item.url)">
+                      <button v-if="'finished' === item.status && item.filename" @click="playVideo(item)"
+                        v-tooltip="'Play video'" class="button is-danger is-light is-small">
                         <span class="icon"><i class="fa-solid fa-play" /></span>
                       </button>
                       <button v-else @click="embed_url = getEmbedable(item.url)" v-tooltip="'Play video'"
-                        class="button is-danger is-light is-small">
+                        class="button is-danger is-small">
                         <span class="icon"><i class="fa-solid fa-play" /></span>
                       </button>
                     </div>
-                    <div class="control" v-if="item.status != 'finished'">
+                    <div class="control" v-if="item.status != 'finished' || !item.filename">
                       <button class="button is-warning is-fullwidth is-small" v-tooltip="'Re-queue video'"
                         @click="reQueueItem(item)">
                         <span class="icon"><i class="fa-solid fa-rotate-right" /></span>
@@ -203,7 +203,7 @@
 
             <div class="card-header-icon">
               <span v-if="hideThumbnail">
-                <a v-if="'finished' === item.status" href="#" @click.prevent="playVideo(item)"
+                <a v-if="'finished' === item.status && item.filename" href="#" @click.prevent="playVideo(item)"
                   v-tooltip="'Play video.'">
                   <span class="icon"><i class="fa-solid fa-play" /></span>
                 </a>
@@ -223,7 +223,7 @@
           </header>
           <div v-if="false === hideThumbnail" class="card-image">
             <figure class="image is-3by1">
-              <span v-if="'finished' === item.status" @click="playVideo(item)" class="play-overlay">
+              <span v-if="'finished' === item.status && item.filename" @click="playVideo(item)" class="play-overlay">
                 <div class="play-icon"></div>
                 <img @load="e => pImg(e)" :src="'/api/thumbnail?url=' + encodePath(item.extras.thumbnail)"
                   v-if="item.extras?.thumbnail" />
@@ -282,7 +282,7 @@
               </div>
             </div>
             <div class="columns is-mobile is-multiline">
-              <div class="column is-half-mobile" v-if="item.status != 'finished'">
+              <div class="column is-half-mobile" v-if="item.status != 'finished' || !item.filename">
                 <a class="button is-warning is-fullwidth" @click="reQueueItem(item)">
                   <span class="icon-text is-block">
                     <span class="icon"><i class="fa-solid fa-rotate-right" /></span>
@@ -512,6 +512,9 @@ const clearIncomplete = () => {
 
 const setIcon = item => {
   if ('finished' === item.status) {
+    if (!item.filename) {
+      return 'fa-solid fa-exclamation'
+    }
     return item.is_live ? 'fa-solid fa-globe' : 'fa-solid fa-circle-check'
   }
 
@@ -524,7 +527,7 @@ const setIcon = item => {
   }
 
   if ('not_live' === item.status) {
-    return 'fa-solid fa-hourglass-half fa-spin'
+    return 'fa-solid fa-headset'
   }
 
   return 'fa-solid fa-circle'
@@ -532,6 +535,9 @@ const setIcon = item => {
 
 const setIconColor = item => {
   if ('finished' === item.status) {
+    if (!item.filename) {
+      return 'has-text-warning'
+    }
     return 'has-text-success'
   }
 
@@ -548,6 +554,9 @@ const setIconColor = item => {
 
 const setStatus = item => {
   if ('finished' === item.status) {
+    if (!item.filename) {
+      return 'Skipped?'
+    }
     return item.is_live ? 'Live Ended' : 'Completed'
   }
 

--- a/ui/components/History.vue
+++ b/ui/components/History.vue
@@ -626,9 +626,9 @@ const reQueueItem = item => {
     url: item.url,
     preset: item.preset,
     folder: item.folder,
-    config: item.config,
     cookies: item.cookies,
     template: item.template,
+    cli: item?.cli,
     extras: extras
   })
 }

--- a/ui/components/NewDownload.vue
+++ b/ui/components/NewDownload.vue
@@ -23,9 +23,16 @@
                     <select id="preset" class="is-fullwidth"
                       :disabled="!socket.isConnected || addInProgress || hasFormatInConfig" v-model="selectedPreset"
                       v-tooltip.bottom="hasFormatInConfig ? 'Presets are disabled. Format key is present in the Command arguments for yt-dlp.' : ''">
-                      <option v-for="item in config.presets" :key="item.name" :value="item.name">
-                        {{ item.name }}
-                      </option>
+                      <optgroup label="Default presets">
+                        <option v-for="item in filter_presets(true)" :key="item.name" :value="item.name">
+                          {{ item.name }}
+                        </option>
+                      </optgroup>
+                      <optgroup label="Custom presets" v-if="config?.presets.filter(p => !p?.default).length > 0">
+                        <option v-for="item in filter_presets(false)" :key="item.name" :value="item.name">
+                          {{ item.name }}
+                        </option>
+                      </optgroup>
                     </select>
                   </div>
                 </div>
@@ -273,4 +280,7 @@ const hasFormatInConfig = computed(() => {
     return true
   }
 })
+
+const filter_presets = (flag = true) => config.presets.filter(item => item.default === flag)
+
 </script>

--- a/ui/components/NewDownload.vue
+++ b/ui/components/NewDownload.vue
@@ -276,9 +276,8 @@ const hasFormatInConfig = computed(() => {
   if (!ytdlp_cli.value) {
     return false
   }
-  if (ytdlp_cli.value.includes('-f') || ytdlp_cli.value.includes('--format')) {
-    return true
-  }
+
+  return /(?<!\w)(-f|--format)(=|:)?(?!\w)/.test(ytdlp_cli.value)
 })
 
 const filter_presets = (flag = true) => config.presets.filter(item => item.default === flag)

--- a/ui/components/PresetForm.vue
+++ b/ui/components/PresetForm.vue
@@ -444,7 +444,7 @@ const importItem = async () => {
     }
 
     if (item.template) {
-      form.template = item.output_template
+      form.template = item.template
     }
 
     if (item.folder) {

--- a/ui/components/PresetForm.vue
+++ b/ui/components/PresetForm.vue
@@ -1,44 +1,6 @@
 <template>
   <main class="columns mt-2 is-multiline">
     <div class="column is-12">
-      <h1 class="is-unselectable is-pointer title is-5" @click="convertExpanded = !convertExpanded">
-        <span class="icon-text">
-          <span class="icon"><i class="fa-solid" :class="convertExpanded ? 'fa-arrow-up' : 'fa-arrow-down'" /></span>
-          <span>Convert yt-dlp cli options.</span>
-        </span>
-      </h1>
-      <form autocomplete="off" id="convertOpts" @submit.prevent="convertOptions()" v-if="convertExpanded">
-        <div class="box">
-          <label class="label" for="opts">
-            yt-dlp CLI options
-          </label>
-
-          <div class="field has-addons">
-
-            <div class="control has-icons-left is-expanded">
-              <input type="text" class="input" id="opts" v-model="opts"
-                placeholder="-x --audio-format mp3 -f bestaudio">
-              <span class="icon is-small is-left"><i class="fa-solid fa-n" /></span>
-            </div>
-
-            <div class="control">
-              <button form="convertOpts" class="button is-primary" :disabled="convertInProgress || !opts" type="submit"
-                :class="{ 'is-loading': convertInProgress }">
-                <span class="icon"><i class="fa-solid fa-cog" /></span>
-                <span>Convert</span>
-              </button>
-            </div>
-
-          </div>
-          <p class="help">
-            <span class="icon"><i class="fa-solid fa-info" /></span>
-            <span>Convert yt-dlp CLI options to JSON format. This will overwrite the current form fields.</span>
-          </p>
-        </div>
-      </form>
-    </div>
-
-    <div class="column is-12">
       <form autocomplete="off" id="presetForm" @submit.prevent="checkInfo()">
         <div class="card">
           <div class="card-header">
@@ -157,43 +119,21 @@
                 </div>
               </div>
 
-              <div class="column is-6-tablet is-12-mobile">
+              <div class="column is-12">
                 <div class="field">
-                  <label class="label is-inline" for="args" v-tooltip="'Extends current global yt-dlp config. (JSON)'">
-                    JSON yt-dlp config
+                  <label class="label is-inline" for="cli_options">
+                    Command arguments for yt-dlp
                   </label>
                   <div class="control">
-                    <textarea class="textarea" id="args" v-model="form.args" :disabled="addInProgress"
-                      placeholder="{}" />
+                    <input type="text" class="input" v-model="form.cli" id="cli_options" :disabled="addInProgress"
+                      placeholder="command options to use, e.g. --no-embed-metadata --no-embed-thumbnail">
                   </div>
                   <span class="help">
                     <span class="icon"><i class="fa-solid fa-info" /></span>
-                    <span>Extends current global yt-dlp config with given options. Some fields are ignored like
-                      <code>cookiefile</code>, <code>paths</code>, and <code>outtmpl</code> etc. Warning: Use with
-                      caution
-                      some of those options can break yt-dlp or the frontend.</span>
-                  </span>
-                </div>
-              </div>
-
-              <div class="column is-6-tablet is-12-mobile">
-                <div class="field">
-                  <label class="label is-inline" for="postprocessors"
-                    v-tooltip="'Things to do after download is done.'">
-                    JSON yt-dlp Post-Processors
-                  </label>
-                  <div class="control">
-                    <textarea class="textarea" id="postprocessors" v-model="form.postprocessors"
-                      :disabled="addInProgress" placeholder="[]" />
-                  </div>
-                  <span class="help">
-                    <span class="icon"><i class="fa-solid fa-info" /></span>
-                    <span>
-                      Post-processing operations, refer to <NuxtLink
-                        href="https://github.com/yt-dlp/yt-dlp/tree/master/yt_dlp/postprocessor" target="blank">this url
-                      </NuxtLink> for more info. It's easier for you to use the <b>Convert CLI options</b> to get what
-                      you
-                      want and it will auto-populate the fields if necessary.
+                    <span>yt-dlp cli arguments. Check <NuxtLink target="_blank"
+                        to="https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#general-options">this page</NuxtLink>.
+                      For more info. <span class="has-text-danger">Not all options are supported some are ignored. Use
+                        with caution those arguments can break yt-dlp or the frontend.</span>
                     </span>
                   </span>
                 </div>
@@ -214,6 +154,56 @@
                         Recommended addon</NuxtLink> by yt-dlp to export cookies. The cookies MUST be in Netscape HTTP
                       Cookie format.
                     </span>
+                  </span>
+                </div>
+              </div>
+              <div class="column is-12" v-if="has_data(form?.args) || has_data(form?.postprocessors)">
+                <Message title="Deprecation Warning" class="is-background-warning-80 has-text-dark"
+                  icon="fas fa-exclamation-circle">
+                  <ul>
+                    <li>
+                      The <code>JSON yt-dlp config</code> and <code>JSON yt-dlp Post-Processors</code> fields are
+                      deprecated and will be removed in the future. Please use the <b>Command arguments for yt-dlp</b>
+                      field instead. The deprecated fields will still be working for now but they will stop, we suggest
+                      that you migrate to the new field. as soon as possible to avoid any issues. No support will be
+                      given for the deprecated fields.
+                    </li>
+                    <li>
+                      If both fields are set, the <b>Command arguments for yt-dlp</b> field will take precedence over
+                      the deprecated fields. and when you click save it will remove the deprecated fields.
+                    </li>
+                  </ul>
+                </Message>
+              </div>
+              <div class="column is-6-tablet is-12-mobile" v-if="has_data(form?.args)">
+                <div class="field">
+                  <label class="label is-inline" for="args" v-tooltip="'Extends current global yt-dlp config. (JSON)'">
+                    JSON yt-dlp config <span class="has-text-danger">(DEPRECATED)</span>
+                  </label>
+                  <div class="control">
+                    <textarea class="textarea" id="args" v-model="form.args" :disabled="addInProgress"
+                      placeholder="{}" />
+                  </div>
+                  <span class="help has-text-danger">
+                    <span class="icon"><i class="fa-solid fa-info" /></span>
+                    <span>Deprecated, use <b>Command arguments for yt-dlp</b> field instead. </span>
+                  </span>
+                </div>
+              </div>
+
+              <div class="column is-6-tablet is-12-mobile" v-if="has_data(form?.postprocessors)">
+                <div class="field">
+                  <label class="label is-inline" for="postprocessors"
+                    v-tooltip="'Things to do after download is done.'">
+                    JSON yt-dlp Post-Processors <span class="has-text-danger">(DEPRECATED)</span>
+                  </label>
+                  <div class="control">
+                    <textarea class="textarea" id="postprocessors" v-model="form.postprocessors"
+                      :disabled="addInProgress" placeholder="[]" />
+                  </div>
+                  <span class="help has-text-danger">
+                    <span class="icon"><i class="fa-solid fa-info" /></span>
+                    <span>Deprecated, use <b>Command arguments for yt-dlp</b> field instead. </span>
                   </span>
                 </div>
               </div>
@@ -239,6 +229,7 @@
         </div>
       </form>
     </div>
+
     <datalist id="folders" v-if="config?.folders">
       <option v-for="dir in config.folders" :key="dir" :value="dir" />
     </datalist>
@@ -273,14 +264,15 @@ const props = defineProps({
 
 const config = useConfigStore()
 const toast = useToast()
-const convertInProgress = ref(false)
 const form = reactive(JSON.parse(JSON.stringify(props.preset)))
-const opts = ref('')
 const import_string = ref('')
 const showImport = useStorage('showImport', false);
-const convertExpanded = ref(false)
 
 onMounted(() => {
+  if (props.preset?.cli && '' !== props.preset?.cli) {
+    return
+  }
+
   if (props.preset?.args && (typeof props.preset.args === 'object')) {
     form.args = JSON.stringify(props.preset.args, null, 2)
   }
@@ -297,6 +289,14 @@ const checkInfo = async () => {
       toast.error(`The ${key} field is required.`);
       return
     }
+  }
+
+  if (form?.cli && '' !== form.cli) {
+    const options = await convertOptions(form.cli);
+    if (null === options) {
+      return
+    }
+    form.cli = form.cli.trim()
   }
 
   let copy = JSON.parse(JSON.stringify(form));
@@ -319,29 +319,47 @@ const checkInfo = async () => {
     return;
   }
 
-  if (typeof copy.args === 'object') {
-    copy.args = JSON.stringify(copy.args, null, 2);
-  }
+  if (form?.cli && '' !== form.cli) {
+    if ((has_data(copy?.args) || has_data(copy?.postprocessors))) {
+      if (false === confirm('cli options are set, this will remove the JSON yt-dlp config and Post-Processors. Are you sure?')) {
+        toast.warning('User cancelled the operation.')
+        return
+      }
+    }
 
-  if (typeof copy.postprocessors === 'object') {
-    copy.postprocessors = JSON.stringify(copy.postprocessors, null, 2);
-  }
+    if (copy?.args) {
+      delete copy.args
+    }
 
-  if (copy.args) {
-    try {
-      copy.args = JSON.parse(copy.args)
-    } catch (e) {
-      toast.error(`Invalid JSON yt-dlp config. ${e.message}`)
-      return;
+    if (copy?.postprocessors) {
+      delete copy.postprocessors
     }
   }
+  else {
+    if (typeof copy.args === 'object') {
+      copy.args = JSON.stringify(copy.args, null, 2);
+    }
 
-  if (copy.postprocessors) {
-    try {
-      copy.postprocessors = JSON.parse(copy.postprocessors)
-    } catch (e) {
-      toast.error(`Invalid JSON yt-dlp Post-Processors. ${e.message}`)
-      return;
+    if (typeof copy.postprocessors === 'object') {
+      copy.postprocessors = JSON.stringify(copy.postprocessors, null, 2);
+    }
+
+    if (copy?.args) {
+      try {
+        copy.args = JSON.parse(copy.args)
+      } catch (e) {
+        toast.error(`Invalid JSON yt-dlp config. ${e.message}`)
+        return;
+      }
+    }
+
+    if (copy?.postprocessors) {
+      try {
+        copy.postprocessors = JSON.parse(copy.postprocessors)
+      } catch (e) {
+        toast.error(`Invalid JSON yt-dlp Post-Processors. ${e.message}`)
+        return;
+      }
     }
   }
 
@@ -355,30 +373,9 @@ const checkInfo = async () => {
   emitter('submit', { reference: toRaw(props.reference), preset: toRaw(copy) });
 }
 
-const convertOptions = async () => {
-  if (convertInProgress.value) {
-    return
-  }
-
-  if (form.format || form.args || form.postprocessors || form.template || form.folder) {
-    if (false === confirm('This will overwrite the current form fields. Are you sure?')) {
-      return
-    }
-  }
-
+const convertOptions = async args => {
   try {
-    convertInProgress.value = true
-    const response = await convertCliOptions(opts.value)
-
-    if (!response.opts) {
-      toast.error('Failed to convert options.')
-      return
-    }
-
-    if (response.opts.format) {
-      form.format = response.opts.format
-      delete response.opts.format
-    }
+    const response = await convertCliOptions(args)
 
     if (response.output_template) {
       form.template = response.output_template
@@ -388,18 +385,16 @@ const convertOptions = async () => {
       form.folder = response.download_path
     }
 
-    if (response.opts.postprocessors) {
-      form.postprocessors = JSON.stringify(response.opts.postprocessors, null, 2)
-      delete response.opts.postprocessors
+    if (response.format) {
+      form.format = response.format
     }
 
-    form.args = JSON.stringify(response.opts, null, 2)
-    opts.value = ''
+    return response.opts
   } catch (e) {
     toast.error(e.message)
-  } finally {
-    convertInProgress.value = false
   }
+
+  return null;
 }
 
 const importItem = async () => {
@@ -422,13 +417,15 @@ const importItem = async () => {
   try {
     const item = JSON.parse(val)
 
+    console.log(item)
+
     if ('preset' !== item._type) {
       toast.error(`Invalid import string. Expected type 'preset', got '${item._type}'.`)
       import_string.value = ''
       return
     }
 
-    if (form.format || form.args || form.postprocessors) {
+    if (form.format || form.cli) {
       if (false === confirm('This will overwrite the current form fields. Are you sure?')) {
         return
       }
@@ -442,15 +439,11 @@ const importItem = async () => {
       form.format = item.format
     }
 
-    if (item.args) {
-      form.args = JSON.stringify(item.args, null, 2)
+    if (item.cli) {
+      form.cli = item.cli
     }
 
-    if (item.postprocessors) {
-      form.postprocessors = JSON.stringify(item.postprocessors, null, 2)
-    }
-
-    if (item.output_template) {
+    if (item.template) {
       form.template = item.output_template
     }
 
@@ -465,4 +458,5 @@ const importItem = async () => {
     toast.error(`Failed to string. ${e.message}`)
   }
 }
+
 </script>

--- a/ui/components/TaskForm.vue
+++ b/ui/components/TaskForm.vue
@@ -388,9 +388,8 @@ const hasFormatInConfig = computed(() => {
   if (!form?.cli) {
     return false
   }
-  if (form.cli.includes('-f') || form.cli.includes('--format')) {
-    return true
-  }
+
+  return /(?<!\w)(-f|--format)(=|:)?(?!\w)/.test(form.cli)
 })
 
 const filter_presets = (flag = true) => config.presets.filter(item => item.default === flag)

--- a/ui/components/TaskForm.vue
+++ b/ui/components/TaskForm.vue
@@ -84,7 +84,8 @@
                   <div class="control has-icons-left">
                     <div class="select is-fullwidth">
                       <select id="preset" class="is-fullwidth" v-model="form.preset"
-                        :disabled="addInProgress || hasFormatInConfig">
+                        :disabled="addInProgress || hasFormatInConfig"
+                        v-tooltip.bottom="hasFormatInConfig ? 'Presets are disabled. Format key is present in the command arguments for yt-dlp.' : ''">
                         <option v-for="item in config.presets" :key="item.name" :value="item.name">
                           {{ item.name }}
                         </option>
@@ -176,15 +177,12 @@
                     <span class="icon"><i class="fa-solid fa-info" /></span>
                     <span>yt-dlp cli arguments. Check <NuxtLink target="_blank"
                         to="https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#general-options">this page</NuxtLink>.
-                      For more info. Some arguments are ignored by default. Warning: Use with
-                      caution some of those options can break yt-dlp or the frontend. <span class="has-text-danger">If
-                        <code>-f, --format</code> argument is present, the preset and all it's options will be
-                        ignored</span>.
+                      For more info. <span class="has-text-danger">Not all options are supported some are ignored. Use
+                        with caution those arguments can break yt-dlp or the frontend.</span>
                     </span>
                   </span>
                 </div>
               </div>
-
             </div>
           </div>
 

--- a/ui/components/TaskForm.vue
+++ b/ui/components/TaskForm.vue
@@ -86,9 +86,16 @@
                       <select id="preset" class="is-fullwidth" v-model="form.preset"
                         :disabled="addInProgress || hasFormatInConfig"
                         v-tooltip.bottom="hasFormatInConfig ? 'Presets are disabled. Format key is present in the command arguments for yt-dlp.' : ''">
-                        <option v-for="item in config.presets" :key="item.name" :value="item.name">
-                          {{ item.name }}
-                        </option>
+                        <optgroup label="Default presets">
+                          <option v-for="item in filter_presets(true)" :key="item.name" :value="item.name">
+                            {{ item.name }}
+                          </option>
+                        </optgroup>
+                        <optgroup label="Custom presets" v-if="config?.presets.filter(p => !p?.default).length > 0">
+                          <option v-for="item in filter_presets(false)" :key="item.name" :value="item.name">
+                            {{ item.name }}
+                          </option>
+                        </optgroup>
                       </select>
                     </div>
                     <span class="icon is-small is-left"><i class="fa-solid fa-tv" /></span>
@@ -385,4 +392,7 @@ const hasFormatInConfig = computed(() => {
     return true
   }
 })
+
+const filter_presets = (flag = true) => config.presets.filter(item => item.default === flag)
+
 </script>

--- a/ui/components/TaskForm.vue
+++ b/ui/components/TaskForm.vue
@@ -50,7 +50,6 @@
                 </span>
               </div>
 
-
               <div class="column is-6-tablet is-12-mobile">
                 <div class="field">
                   <label class="label is-inline" for="name" v-text="'Name'" />
@@ -81,14 +80,11 @@
 
               <div class="column is-6-tablet is-12-mobile">
                 <div class="field">
-                  <label class="label is-inline" for="folder">
-                    Preset
-                  </label>
+                  <label class="label is-inline" for="preset">Preset</label>
                   <div class="control has-icons-left">
                     <div class="select is-fullwidth">
                       <select id="preset" class="is-fullwidth" v-model="form.preset"
-                        :disabled="addInProgress || hasFormatInConfig"
-                        v-tooltip.bottom="hasFormatInConfig ? 'Presets are disabled. Format key is present in the config.' : ''">
+                        :disabled="addInProgress || hasFormatInConfig">
                         <option v-for="item in config.presets" :key="item.name" :value="item.name">
                           {{ item.name }}
                         </option>
@@ -98,8 +94,10 @@
                   </div>
                   <span class="help">
                     <span class="icon"><i class="fa-solid fa-info" /></span>
-                    <span>Select the preset to use for this URL. The preset will be ignored if format key is present in
-                      config.</span>
+                    <span>Select the preset to use for this URL. <span class="text-has-danger">If the
+                        <code>-f, --format</code> argument is present in the command line options, the preset and all
+                        it's options will be ignored.</span>
+                    </span>
                   </span>
                 </div>
               </div>
@@ -126,7 +124,7 @@
                 </div>
               </div>
 
-              <div class="column is-6-tablet is-12-mobile" v-if="showAdvanced">
+              <div class="column is-6-tablet is-12-mobile">
                 <div class="field">
                   <label class="label is-inline" for="folder">
                     Download path
@@ -138,24 +136,25 @@
                   </div>
                   <span class="help">
                     <span class="icon"><i class="fa-solid fa-info" /></span>
-                    <span>Downloads are relative to download path, defaults to root path if not set.</span>
+                    <span>Paths are relative to global download path, defaults to preset download path if set otherwise,
+                      fallback root path if not set.</span>
                   </span>
                 </div>
               </div>
 
-              <div class="column is-6-tablet is-12-mobile" v-if="showAdvanced">
+              <div class="column is-6-tablet is-12-mobile">
                 <div class="field">
                   <label class="label is-inline" for="output_template">
                     Output template
                   </label>
                   <div class="control has-icons-left">
-                    <input type="text" class="input" id="output_template" placeholder="The output template to use"
-                      v-model="form.template" :disabled="addInProgress">
+                    <input type="text" class="input" id="output_template" :disabled="addInProgress"
+                      placeholder="Leave empty to use default template." v-model="form.template">
                     <span class="icon is-small is-left"><i class="fa-solid fa-file" /></span>
                   </div>
                   <span class="help">
                     <span class="icon"><i class="fa-solid fa-info" /></span>
-                    <span>The output template to use, if not set, it will defaults to
+                    <span>Use this output template if non are given with URL. if not set, it will defaults to
                       <code>{{ config.app.output_template }}</code>.
                       For more information <NuxtLink href="https://github.com/yt-dlp/yt-dlp#output-template"
                         target="_blank">visit this url</NuxtLink>.
@@ -164,41 +163,24 @@
                 </div>
               </div>
 
-              <div class="column is-6-tablet is-12-mobile" v-if="showAdvanced">
+              <div class="column is-12">
                 <div class="field">
-                  <label class="label is-inline" for="config"
-                    v-tooltip="'Extends current global yt-dlp config. (JSON)'">
-                    JSON yt-dlp config or CLI options. <NuxtLink
-                      v-if="form.config && (typeof form.config === 'string') && !form.config.trim().startsWith('{')"
-                      @click="convertOptions()">Convert to JSON</NuxtLink>
+                  <label class="label is-inline" for="cli_options">
+                    Command arguments for yt-dlp
                   </label>
                   <div class="control">
-                    <textarea class="textarea" id="config" v-model="form.config" :disabled="addInProgress"
-                      placeholder="--no-embed-metadata --no-embed-thumbnail"></textarea>
+                    <input type="text" class="input" v-model="form.cli" id="cli_options" :disabled="addInProgress"
+                      placeholder="command options to use, e.g. --no-embed-metadata --no-embed-thumbnail">
                   </div>
                   <span class="help">
                     <span class="icon"><i class="fa-solid fa-info" /></span>
-                    <span> Extends current global yt-dlp config with given options. Some fields are ignored like
-                      <code>cookiefile</code>, <code>paths</code>, and <code>outtmpl</code> etc. Warning: Use with
-                      caution
-                      some of those options can break yt-dlp or the frontend.</span>
-                  </span>
-                </div>
-              </div>
-
-              <div class="column is-6-tablet is-12-mobile" v-if="showAdvanced">
-                <div class="field">
-                  <label class="label is-inline" for="cookies"
-                    v-tooltip="'Netscape HTTP Cookie format.'">Cookies</label>
-                  <div class="control">
-                    <textarea class="textarea is-pre" id="cookies" v-model="form.cookies" :disabled="addInProgress" />
-                  </div>
-                  <span class="help">
-                    <span class="icon"><i class="fa-solid fa-info" /></span>
-                    <span>Use the <NuxtLink target="_blank"
-                        to="https://github.com/yt-dlp/yt-dlp/wiki/FAQ#how-do-i-pass-cookies-to-yt-dlp">
-                        Recommended addon</NuxtLink> by yt-dlp to export cookies. The cookies MUST be in Netscape HTTP
-                      Cookie format.</span>
+                    <span>yt-dlp cli arguments. Check <NuxtLink target="_blank"
+                        to="https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#general-options">this page</NuxtLink>.
+                      For more info. Some arguments are ignored by default. Warning: Use with
+                      caution some of those options can break yt-dlp or the frontend. <span class="has-text-danger">If
+                        <code>-f, --format</code> argument is present, the preset and all it's options will be
+                        ignored</span>.
+                    </span>
                   </span>
                 </div>
               </div>
@@ -221,12 +203,6 @@
                 <span>Cancel</span>
               </button>
             </p>
-            <p class="card-footer-item">
-              <button class="button is-fullwidth is-info" type="button" @click="showAdvanced = !showAdvanced">
-                <span class="icon"><i class="fa-solid fa-cog" /></span>
-                <span>Advanced</span>
-              </button>
-            </p>
           </div>
         </div>
       </form>
@@ -244,8 +220,6 @@ import { CronExpressionParser } from 'cron-parser'
 const emitter = defineEmits(['cancel', 'submit']);
 const toast = useToast();
 const config = useConfigStore();
-const convertInProgress = ref(false);
-const showAdvanced = useStorage('task.showAdvanced', false);
 const showImport = useStorage('showImport', false);
 const import_string = ref('');
 
@@ -269,10 +243,6 @@ const props = defineProps({
 const form = reactive(props.task);
 
 onMounted(() => {
-  if (props.task?.config && (typeof props.task.config === 'object')) {
-    form.config = JSON.stringify(props.task.config, null, 4);
-  }
-
   if (!props.task?.preset || '' === props.task.preset) {
     form.preset = toRaw(config.app.default_preset);
   }
@@ -304,59 +274,16 @@ const checkInfo = async () => {
     return;
   }
 
-  if (typeof form.config === 'object') {
-    form.config = JSON.stringify(form.config, null, 4);
-  }
-
-  if (form.config && form.config && !form.config.trim().startsWith('{')) {
-    await convertOptions();
-  }
-
-  if (form.config) {
-    try {
-      form.config = JSON.parse(form.config)
-    } catch (e) {
-      toast.error(`Invalid JSON yt-dlp config. ${e.message}`)
-      return;
+  if (form?.cli && '' !== form.cli) {
+    const options = await convertOptions(form.cli);
+    if (null === options) {
+      return
     }
+    form.cli = form.cli.trim(" ")
   }
 
   emitter('submit', { reference: toRaw(props.reference), task: toRaw(form) });
 }
-
-const convertOptions = async () => {
-  if (convertInProgress.value) {
-    return
-  }
-
-  try {
-    convertInProgress.value = true
-    const response = await convertCliOptions(form.config)
-    form.config = JSON.stringify(response.opts, null, 2)
-    if (response.output_template) {
-      form.template = response.output_template
-    }
-    if (response.download_path) {
-      form.folder = response.download_path
-    }
-  } catch (e) {
-    toast.error(e.message)
-  } finally {
-    convertInProgress.value = false
-  }
-}
-
-const hasFormatInConfig = computed(() => {
-  if (!form.config) {
-    return false
-  }
-  try {
-    const config = JSON.parse(form.config)
-    return "format" in config
-  } catch (e) {
-    return false
-  }
-})
 
 const importItem = async () => {
   let val = import_string.value.trim()
@@ -384,7 +311,7 @@ const importItem = async () => {
       return
     }
 
-    if (form.config || form.url || form.timer) {
+    if (form.url || form.timer) {
       if (false === confirm('This will overwrite the current form fields. Are you sure?')) {
         return
       }
@@ -398,8 +325,8 @@ const importItem = async () => {
       form.url = item.url
     }
 
-    if (item.preset) {
-      form.preset = item.preset
+    if (item.template) {
+      form.template = item.template
     }
 
     if (item.timer) {
@@ -410,12 +337,19 @@ const importItem = async () => {
       form.folder = item.folder
     }
 
-    if (item.template) {
-      form.template = item.template
+    if (item.cli) {
+      form.cli = item.cli
     }
 
-    if (item.config) {
-      form.config = JSON.stringify(item.config, null, 2)
+    if (item.preset) {
+      //  -- check if the preset exists in config.presets
+      const preset = config.presets.find(p => p.name === item.preset)
+      if (!preset) {
+        toast.warning(`Preset '${item.preset}' not found. Preset will be set to default.`)
+        form.preset = 'default'
+      } else {
+        form.preset = item.preset
+      }
     }
 
     import_string.value = ''
@@ -424,4 +358,33 @@ const importItem = async () => {
     toast.error(`Failed to import string. ${e.message}`)
   }
 }
+
+const convertOptions = async args => {
+  try {
+    const response = await convertCliOptions(args)
+
+    if (response.output_template) {
+      form.template = response.output_template
+    }
+
+    if (response.download_path) {
+      form.folder = response.download_path
+    }
+
+    return response.opts
+  } catch (e) {
+    toast.error(e.message)
+  }
+
+  return null;
+}
+
+const hasFormatInConfig = computed(() => {
+  if (!form?.cli) {
+    return false
+  }
+  if (form.cli.includes('-f') || form.cli.includes('--format')) {
+    return true
+  }
+})
 </script>

--- a/ui/pages/presets.vue
+++ b/ui/pages/presets.vue
@@ -80,7 +80,8 @@ div.is-centered {
                     <hr>
                   </template>
 
-                  <p class="is-text-overflow">
+                  <p class="is-text-overflow"
+                    v-if="item?.format && false === ['default', 'not_set'].includes(item.format)">
                     <span class="icon"><i class="fa-solid fa-f" /></span>
                     <span v-text="item.format" />
                   </p>

--- a/ui/pages/presets.vue
+++ b/ui/pages/presets.vue
@@ -76,8 +76,8 @@ div.is-centered {
                       <span class="icon"><i class="fa-solid fa-triangle-exclamation" /></span>
                       <span>The preset is using deprecated options. It is recommended to update the preset to use the
                         new options. It will cease to work in future versions.</span>
-                      <hr>
                     </p>
+                    <hr>
                   </template>
 
                   <p class="is-text-overflow">

--- a/ui/pages/presets.vue
+++ b/ui/pages/presets.vue
@@ -71,6 +71,15 @@ div.is-centered {
               </header>
               <div class="card-content">
                 <div class="content">
+                  <template v-if="has_data(item?.args) || has_data(item.postprocessors)">
+                    <p class="has-text-danger is-5 has-text-bold">
+                      <span class="icon"><i class="fa-solid fa-triangle-exclamation" /></span>
+                      <span>The preset is using deprecated options. It is recommended to update the preset to use the
+                        new options. It will cease to work in future versions.</span>
+                      <hr>
+                    </p>
+                  </template>
+
                   <p class="is-text-overflow">
                     <span class="icon"><i class="fa-solid fa-f" /></span>
                     <span v-text="item.format" />
@@ -82,6 +91,10 @@ div.is-centered {
                   <p class="is-text-overflow" v-if="item.template">
                     <span class="icon"><i class="fa-solid fa-file" /></span>
                     <span>{{ item.template }}</span>
+                  </p>
+                  <p class="is-text-overflow" v-if="item.cli">
+                    <span class="icon"><i class="fa-solid fa-terminal" /></span>
+                    <span>{{ item.cli }}</span>
                   </p>
                   <p class="is-text-overflow" v-if="item.cookies">
                     <span class="icon"><i class="fa-solid fa-cookie" /></span>
@@ -293,12 +306,9 @@ const exportItem = item => {
     }
   })
 
-  if (data.args && typeof data.args === "string") {
-    data.args = JSON.parse(data.args)
-  }
-
-  if (data.postprocessors && typeof data.postprocessors === "string") {
-    data.postprocessors = JSON.parse(data.postprocessors)
+  if (has_data(data?.args) || has_data(data?.postprocessors)) {
+    toast.error("v1.0 presets are no longer supported target for export. Please update your preset.")
+    return
   }
 
   let userData = {}
@@ -311,7 +321,7 @@ const exportItem = item => {
   }
 
   userData['_type'] = 'preset'
-  userData['_version'] = '1.0'
+  userData['_version'] = '2.0'
 
   return copyText(base64UrlEncode(JSON.stringify(userData)))
 }

--- a/ui/stores/ConfigStore.js
+++ b/ui/stores/ConfigStore.js
@@ -22,7 +22,12 @@ const CONFIG_KEYS = {
   presets: [
     {
       'name': 'default',
-      'format': 'default'
+      'format': 'default',
+      'folder': '',
+      'template': '',
+      'cookies': '',
+      'cli': '',
+      'default': true
     }
   ],
   folders: [],

--- a/ui/utils/index.js
+++ b/ui/utils/index.js
@@ -428,6 +428,38 @@ const base64UrlDecode = input => {
   return atob(base64);
 }
 
+
+/**
+ * Check if array or object has data.
+ *
+ * @param {string} item - The item to check
+ * @returns {boolean} - True if the item has data, false otherwise.
+ */
+const has_data = item => {
+  if (!item) {
+    return false
+  }
+
+  if (typeof item === 'string') {
+    try {
+      item = JSON.parse(item)
+    } catch (e) {
+      return true
+    }
+  }
+
+  try {
+    if (typeof item === 'object') {
+      return Object.keys(item).length > 0
+    }
+    return item.length > 0
+  } catch (e) {
+    console.error(e)
+  }
+
+  return false
+}
+
 export {
   ag_set,
   ag,
@@ -452,4 +484,5 @@ export {
   convertCliOptions,
   base64UrlEncode,
   base64UrlDecode,
+  has_data,
 }


### PR DESCRIPTION
To be frank, supporting `JSON yt-dlp config` is difficult and error prune due to the unpredictability  of how yt-dlp interpret the config, sometimes requiring function call, other times converting to and from classes etc, as you can see from the work around we have it's proven to not be sustainable. As such, I have decided to retire JSON support and rely directly on `yt-dlp cli command options` we can reasonable be sure that the options will always be in what `yt-dlp` expects. This will lead to problems most likely as some of those options conflict with the options we provide. As such, we will blacklist options and removed options that might break yt-dlp or the frontend.


This rollout will be in stages, the first stage is completed with this PR which include the following:

# Stage 1
* Removed JSON config from new download form and replaced with `Command arguments for yt-dlp`.
* Removed JSON config for tasks with no fallback for existing options, and added `Command arguments for yt-dlp`.
* Deprecate the JSON config & post-processor fields in presets, added `Command arguments for yt-dlp` as replacement.
* * If you are making new preset the fields are hidden from view and will no longer show.
* * If you edit existing preset that doesn't have any JSON config or post-processors the fields will be hidden.
* * If you have existing preset that has any of the fields set, it will show giant warning about the deprecation and suggests moving to the new field.
* * If the new field is used, a warning will be issued to tell the user if the field is used the JSON config & post-processor will be removed.
* * If both the JSON fields and  `Command arguments for yt-dlp` are set, the command arguments will take priority over the JSON fields. 

# Stage 2
* Completely remove support for the JSON config from all parts of the application to streamline the development.
* Remove backwards compatibility for v1.0 presets, they will no longer function.


===============

This pull request includes several changes to the `yt-dlp` Web GUI project, focusing on removing support for JSON config and cookies, adding support for CLI options, and improving the handling of presets and tasks. The most important changes include modifications to the `Task` and `Preset` classes, updates to the JSON configuration files, and enhancements to the user interface.

### Removal of JSON Config and Cookies, Addition of CLI Options:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R16): Removed support for `yt-dlp JSON config` and `output format`, and updated to support `cli options` and `cookies`.
* [`app/library/Tasks.py`](diffhunk://#diff-cb5048567bbfa27afeda8641244f1ed0e61453d773861c897e322678ac666264L6-R6): Removed `cookies` and `config` attributes from `Task`, added `cli` attribute, and updated methods to handle the new attribute. [[1]](diffhunk://#diff-cb5048567bbfa27afeda8641244f1ed0e61453d773861c897e322678ac666264L6-R6) [[2]](diffhunk://#diff-cb5048567bbfa27afeda8641244f1ed0e61453d773861c897e322678ac666264L31-R31) [[3]](diffhunk://#diff-cb5048567bbfa27afeda8641244f1ed0e61453d773861c897e322678ac666264L137-R149) [[4]](diffhunk://#diff-cb5048567bbfa27afeda8641244f1ed0e61453d773861c897e322678ac666264R163-R166) [[5]](diffhunk://#diff-cb5048567bbfa27afeda8641244f1ed0e61453d773861c897e322678ac666264L216-R229) [[6]](diffhunk://#diff-cb5048567bbfa27afeda8641244f1ed0e61453d773861c897e322678ac666264R269-R289) [[7]](diffhunk://#diff-cb5048567bbfa27afeda8641244f1ed0e61453d773861c897e322678ac666264L286-R311) [[8]](diffhunk://#diff-cb5048567bbfa27afeda8641244f1ed0e61453d773861c897e322678ac666264L310-R327)
* [`app/library/Presets.py`](diffhunk://#diff-a4ed190f34ad1328a653e8d20680365c8460ffe4826a3d3256bd6a75646350d1R44-R46): Added `cli` attribute to `Preset` and updated the validation method to handle CLI options. [[1]](diffhunk://#diff-a4ed190f34ad1328a653e8d20680365c8460ffe4826a3d3256bd6a75646350d1R44-R46) [[2]](diffhunk://#diff-a4ed190f34ad1328a653e8d20680365c8460ffe4826a3d3256bd6a75646350d1R226-R234)
* [`app/library/presets.json`](diffhunk://#diff-cf9b7c5d3c54efaeae247d932c5f29f51f38b0274b0f47efee9335ac4dafa458R9): Updated presets to use the `cli` attribute instead of `args`. [[1]](diffhunk://#diff-cf9b7c5d3c54efaeae247d932c5f29f51f38b0274b0f47efee9335ac4dafa458R9) [[2]](diffhunk://#diff-cf9b7c5d3c54efaeae247d932c5f29f51f38b0274b0f47efee9335ac4dafa458R19-R49)

### Enhancements to CLI Option Handling:

* [`app/library/Utils.py`](diffhunk://#diff-f84d43da838a47b916d119ccf2590a3072994ba456002592d5900caa73035518R476-R483): Modified `arg_converter` to include a `remove_options` parameter for cleaning default options. (F0bddc15L4R4, [app/library/Utils.pyR476-R483](diffhunk://#diff-f84d43da838a47b916d119ccf2590a3072994ba456002592d5900caa73035518R476-R483))
* [`app/library/YTDLPOpts.py`](diffhunk://#diff-d37158910547c723c86db10bbe69656921077f8e2af5e0ff1822e78305e12e39L7-R7): Updated to use `arg_converter` for handling CLI options in presets. [[1]](diffhunk://#diff-d37158910547c723c86db10bbe69656921077f8e2af5e0ff1822e78305e12e39L7-R7) [[2]](diffhunk://#diff-d37158910547c723c86db10bbe69656921077f8e2af5e0ff1822e78305e12e39R74-R80) [[3]](diffhunk://#diff-d37158910547c723c86db10bbe69656921077f8e2af5e0ff1822e78305e12e39R104)
* [`app/library/common.py`](diffhunk://#diff-c37ef4278370fdea386cdd3daf256795154926d897e827491df4ca059c33f94cR7): Added CLI option parsing in the `format_item` method. [[1]](diffhunk://#diff-c37ef4278370fdea386cdd3daf256795154926d897e827491df4ca059c33f94cR7) [[2]](diffhunk://#diff-c37ef4278370fdea386cdd3daf256795154926d897e827491df4ca059c33f94cR98-R105)

### User Interface Improvements:

* [`ui/components/NewDownload.vue`](diffhunk://#diff-6fabf4a26fdd84def116eb86bc8e77dfdb1553e7f870592c801a4f7c6dd36097L25-R35): Improved the preset selection UI by separating default and custom presets, and added icons to the output template input field. [[1]](diffhunk://#diff-6fabf4a26fdd84def116eb86bc8e77dfdb1553e7f870592c801a4f7c6dd36097L25-R35) [[2]](diffhunk://#diff-6fabf4a26fdd84def116eb86bc8e77dfdb1553e7f870592c801a4f7c6dd36097L62-R80)

### Logging and Debugging Enhancements:

* [`app/library/Download.py`](diffhunk://#diff-c371d628747ee6d313fb7688dc2663db08508b0504ab438c6e8937957bd9bb30L218-R218): Improved logging format for debugging parameters passed to `yt-dlp`.
* [`app/library/HttpAPI.py`](diffhunk://#diff-b9296f201ccb63e0b417d76b4cc77ff90217e462e83409b25e53fd9123d7197aR456-R458): Added support for handling the `format` key in responses. [[1]](diffhunk://#diff-b9296f201ccb63e0b417d76b4cc77ff90217e462e83409b25e53fd9123d7197aR456-R458) [[2]](diffhunk://#diff-b9296f201ccb63e0b417d76b4cc77ff90217e462e83409b25e53fd9123d7197aL875-R883)