### PR TITLE
go with blacklist approach for blocking yt-dlp options.

### DIFF
--- a/app/library/Utils.py
+++ b/app/library/Utils.py
@@ -38,18 +38,11 @@ REMOVE_KEYS: list = [
         "simulate": "--simulate",
         "noprogress": "--no-progress",
         "wait_for_video": "--wait-for-video",
-        "color": "--color",
-        "verbose": "-v, --verbose",
-        "debug_printtraffic": "--print-traffic",
-        "write_pages": "--write-pages",
-        "dump_intermediate_pages": "--dump-pages",
         "progress_delta": " --progress-delta",
         "progress_template": "--progress-template",
         "consoletitle": "--console-title",
         "progress_with_newline": "--newline",
         "forcejson": "-j, --dump-json",
-        "print_to_file": "--print-to-file",
-        "cookiesfrombrowser": "--cookies-from-browser",
     },
 ]
 


### PR DESCRIPTION
This pull request includes a cleanup of the `app/library/Utils.py` file by removing several unused command-line options from the `options` dictionary.

Cleanup:

* [`app/library/Utils.py`](diffhunk://#diff-f84d43da838a47b916d119ccf2590a3072994ba456002592d5900caa73035518L41-L52): Removed the following options: `color`, `verbose`, `debug_printtraffic`, `write_pages`, `dump_intermediate_pages`, and `print_to_file`.