### PR TITLE
Minor logs view update

### DIFF
--- a/app/library/HttpAPI.py
+++ b/app/library/HttpAPI.py
@@ -749,19 +749,22 @@ class HttpAPI(Common):
             )
 
         offset = int(request.query.get("offset", 0))
-        limit = int(request.query.get("limit", 50))
+        limit = int(request.query.get("limit", 100))
         if limit < 1 or limit > 150:
             limit = 50
 
+        logs_data = await read_logfile(
+            file=os.path.join(self.config.config_path, "logs", "app.log"),
+            offset=offset,
+            limit=limit,
+        )
         return web.json_response(
             data={
-                "logs": await read_logfile(
-                    file=os.path.join(self.config.config_path, "logs", "app.log"),
-                    offset=offset,
-                    limit=limit,
-                ),
+                "logs": logs_data["logs"],
                 "offset": offset,
                 "limit": limit,
+                "next_offset": logs_data["next_offset"],
+                "end_is_reached": logs_data["end_is_reached"],
             },
             status=web.HTTPOk.status_code,
             dumps=self.encoder.encode,

--- a/ui/pages/logs.vue
+++ b/ui/pages/logs.vue
@@ -14,7 +14,7 @@
 }
 
 .logbox {
-  background-color: #333;
+  background-color: #1f2229 !important;
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
   min-width: 100%;
   max-height: 73vh;
@@ -22,13 +22,13 @@
   overflow-x: auto;
 }
 
-div.logbox pre {
-  background-color: rgb(31, 34, 41);
+code {
+  background-color: unset;
 }
 
 .logline {
   word-break: break-all;
-  line-height: 2.3em;
+  line-height: 1.75rem;
   padding: 1em;
   color: #fff1b8;
 }
@@ -39,13 +39,13 @@ div.logbox pre {
     <div class="mt-1 columns is-multiline">
       <div class="column is-12 is-clearfix is-unselectable">
         <span class="title is-4">
-          <span class="icon"><i class="fas fa-file-lines" :class="{ 'fa-spin': loading }" /></span>
+          <span class="icon"><i class="fas fa-file-lines" /></span>
           Logs
         </span>
         <div class="is-pulled-right">
           <div class="field is-grouped">
             <div class="control">
-              <button v-if="!autoScroll" @click="scrollToBottom" class="button is-primary">
+              <button v-if="!autoScroll" @click="scrollToBottom(false)" class="button is-primary">
                 <span class="icon"><i class="fas fa-arrow-down"></i></span>
                 <span>Go to Bottom</span>
               </button>
@@ -73,26 +73,42 @@ div.logbox pre {
         </div>
 
         <div class="is-hidden-mobile">
-          <span class="subtitle">The logs are displayed in real-time. You can scroll up to view older logs.</span>
+          <span class="subtitle">The logs are being streamed in real-time. You can scroll up to view older logs.</span>
         </div>
       </div>
-    </div>
 
-    <div class="column is-12">
-      <div class="logbox is-grid" ref="logContainer" @scroll.passive="handleScroll">
-        <pre class="p-1 m-1"><code id="logView" class="p-0 logline is-block"
-                               :class="{ 'is-pre-wrap': true === textWrap, 'is-pre': false === textWrap }"><span
-        v-for="log in filteredItems" :key="log.id" class="is-block"><template
-        v-if="log?.datetime">[<span class="has-tooltip" :title="log.datetime">{{ moment(log.datetime).format('HH:mm:ss') }}</span>]&nbsp;</template>{{
-          log.line }}</span><span class="is-block" v-if="filteredItems.length < 1"><span v-if="query"><span
-      class="has-text-danger">No logs found for the filter: </span><span class="has-text-info">{{ query
-      }}</span></span><span v-else><span class="has-text-danger">No logs available</span></span>
-</span></code></pre>
-        <div ref="bottomMarker"></div>
+      <div class="column is-12">
+        <div class="logbox is-grid" ref="logContainer" @scroll.passive="handleScroll">
+          <code id="logView" class="p-2 logline is-block"
+            :class="{ 'is-pre-wrap': true === textWrap, 'is-pre': false === textWrap }">
+            <span class="is-block m-0 notification is-info is-dark has-text-centered" v-if="reachedEnd && !query">
+              <span class="notification-title">
+                <span class="icon"><i class="fas fa-exclamation-triangle"/></span>
+                No more logs available for this file.
+              </span>
+            </span>
+            <span v-for="log in filteredItems" :key="log.id" class="is-block">
+              <template v-if="log?.datetime">[<span class="has-tooltip" :title="log.datetime">{{ moment(log.datetime).format('HH:mm:ss') }}</span>]</template>
+              {{ log.line }}
+            </span>
+            <span class="is-block" v-if="filteredItems.length < 1">
+                <span class="is-block m-0 notification is-warning is-dark has-text-centered" v-if="query">
+                  <span class="notification-title is-danger">
+                    <span class="icon"><i class="fas fa-filter"/></span>
+                    No logs match this query: <u>{{ query }}</u>
+                  </span>
+                </span>
+                <span v-else>
+                  <span class="has-text-danger">No logs available</span></span>
+              </span>
+          </code>
+          <div ref="bottomMarker"></div>
+        </div>
       </div>
     </div>
   </div>
 </template>
+
 <script setup>
 import moment from 'moment'
 import { request } from '~/utils/index'
@@ -107,13 +123,12 @@ const config = useConfigStore()
 
 const logs = ref([])
 const offset = ref(0)
-const limit = 50
-const maxLogLimit = 1000
 const loading = ref(false)
 const logContainer = ref(null)
 const bottomMarker = ref(null)
 const autoScroll = ref(true)
 const textWrap = ref(true)
+const reachedEnd = ref(false)
 const bg_enable = useStorage('random_bg', true)
 const bg_opacity = useStorage('random_bg_opacity', 0.85)
 
@@ -122,6 +137,7 @@ const toggleFilter = ref(false)
 watch(toggleFilter, () => {
   if (!toggleFilter.value) {
     query.value = ''
+    scrollToBottom(true)
   }
 });
 
@@ -166,14 +182,14 @@ const filteredItems = computed(() => {
 })
 
 const fetchLogs = async () => {
-  if (logs.value.length >= maxLogLimit) {
+  loading.value = true
+
+  if (reachedEnd.value || query.value) {
     return
   }
 
-  loading.value = true
-
   try {
-    const req = await request(`/api/logs?offset=${offset.value}&limit=${limit}`)
+    const req = await request(`/api/logs?offset=${offset.value}`)
     if (!req.ok) {
       toast.error('Failed to fetch logs');
       return
@@ -189,13 +205,16 @@ const fetchLogs = async () => {
 
     if (lines.length) {
       logs.value.unshift(...response.logs)
-      offset.value += lines.length;
-      if (logs.value.length > maxLogLimit) {
-        logs.value.splice(0, logs.value.length - maxLogLimit)
-      }
     }
 
-    // Auto-scroll only if the user was already at the bottom
+    if (response?.next_offset) {
+      offset.value = response.next_offset
+    }
+
+    if (response?.end_is_reached) {
+      reachedEnd.value = true
+    }
+
     nextTick(() => {
       if (autoScroll.value && bottomMarker.value) {
         bottomMarker.value.scrollIntoView({ behavior: 'auto' })
@@ -207,7 +226,6 @@ const fetchLogs = async () => {
     loading.value = false
   }
 }
-
 
 const handleScroll = () => {
   if (!logContainer.value || query.value) {
@@ -233,11 +251,11 @@ const handleScroll = () => {
   }
 }
 
-const scrollToBottom = () => {
+const scrollToBottom = (fast=false) => {
   autoScroll.value = true
   nextTick(() => {
     if (bottomMarker.value) {
-      bottomMarker.value.scrollIntoView({ behavior: 'smooth' })
+      bottomMarker.value.scrollIntoView({ behavior: fast ? 'auto': 'smooth' })
     }
   })
 }
@@ -246,10 +264,6 @@ onMounted(async () => {
   await fetchLogs()
   socket.emit('subscribe', 'log_lines')
   socket.on('log_lines', data => {
-    if (logs.value.length >= maxLogLimit) {
-      logs.value.shift()
-    }
-
     logs.value.push(data)
 
     nextTick(() => {


### PR DESCRIPTION
This pull request includes several changes to improve the log handling and display functionalities. The changes focus on enhancing the log pagination, updating the log display UI, and fixing some issues related to file paths and log fetching.

### Log Handling Improvements:
* [`app/library/HttpAPI.py`](diffhunk://#diff-b9296f201ccb63e0b417d76b4cc77ff90217e462e83409b25e53fd9123d7197aL752-R767): Increased the default log limit from 50 to 100 and added additional pagination metadata to the log response.
* [`app/library/Utils.py`](diffhunk://#diff-f84d43da838a47b916d119ccf2590a3072994ba456002592d5900caa73035518L945-L992): Modified `read_logfile` to return a dictionary with logs and pagination metadata instead of a list of log lines. Updated the function to handle file existence checks using `pathlib.Path` and improved the log fetching logic. [[1]](diffhunk://#diff-f84d43da838a47b916d119ccf2590a3072994ba456002592d5900caa73035518L945-L992) [[2]](diffhunk://#diff-f84d43da838a47b916d119ccf2590a3072994ba456002592d5900caa73035518L1001-R1013) [[3]](diffhunk://#diff-f84d43da838a47b916d119ccf2590a3072994ba456002592d5900caa73035518L1022-R1031)

### UI Enhancements:
* [`ui/pages/logs.vue`](diffhunk://#diff-0100a7468120e054e6e7c4b41b95a377f5ab5232507364c07392679a8d5f6c00L17-R31): Updated the background color of the log box and adjusted the line height for better readability.
* [`ui/pages/logs.vue`](diffhunk://#diff-0100a7468120e054e6e7c4b41b95a377f5ab5232507364c07392679a8d5f6c00L42-R48): Improved the log display by adding notifications for no logs available and no logs matching the query. Added smooth scrolling and better handling of log fetching and pagination. [[1]](diffhunk://#diff-0100a7468120e054e6e7c4b41b95a377f5ab5232507364c07392679a8d5f6c00L42-R48) [[2]](diffhunk://#diff-0100a7468120e054e6e7c4b41b95a377f5ab5232507364c07392679a8d5f6c00L76-R111) [[3]](diffhunk://#diff-0100a7468120e054e6e7c4b41b95a377f5ab5232507364c07392679a8d5f6c00L110-R131) [[4]](diffhunk://#diff-0100a7468120e054e6e7c4b41b95a377f5ab5232507364c07392679a8d5f6c00R140) [[5]](diffhunk://#diff-0100a7468120e054e6e7c4b41b95a377f5ab5232507364c07392679a8d5f6c00L169-R192) [[6]](diffhunk://#diff-0100a7468120e054e6e7c4b41b95a377f5ab5232507364c07392679a8d5f6c00L192-L198) [[7]](diffhunk://#diff-0100a7468120e054e6e7c4b41b95a377f5ab5232507364c07392679a8d5f6c00L211) [[8]](diffhunk://#diff-0100a7468120e054e6e7c4b41b95a377f5ab5232507364c07392679a8d5f6c00L236-R258) [[9]](diffhunk://#diff-0100a7468120e054e6e7c4b41b95a377f5ab5232507364c07392679a8d5f6c00L249-L252)