### PR TITLE
Download as zipfile when downloading multiple files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
   "multidict==6.5.1",
   "dateparser>=1.2.1",
   "defusedxml>=0.7.1",
+  "zipstream-ng>=1.8.0",
 ]
 
 [tool.ruff]

--- a/ui/components/NewDownload.vue
+++ b/ui/components/NewDownload.vue
@@ -389,7 +389,7 @@ onUpdated(async () => {
     form.value.preset = config.app.default_preset
   }
 
-  if (form.value?.preset && !config.presets.some(p => p.name === form.value.preset)) {
+  if (config.isLoaded() && form.value?.preset && !config.presets.some(p => p.name === form.value.preset)) {
     form.value.preset = config.app.default_preset
   }
 })
@@ -401,7 +401,7 @@ onMounted(async () => {
     form.value.preset = config.app.default_preset
   }
 
-  if (form.value?.preset && !config.presets.some(p => p.name === form.value.preset)) {
+  if (config.isLoaded() && form.value?.preset && !config.presets.some(p => p.name === form.value.preset)) {
     form.value.preset = config.app.default_preset
   }
 

--- a/ui/components/Queue.vue
+++ b/ui/components/Queue.vue
@@ -4,7 +4,9 @@
       <span class="icon">
         <i class="fas" :class="showQueue ? 'fa-solid fa-arrow-up' : 'fa-solid fa-arrow-down'" />
       </span>
-      <span>Queue <span v-if="hasQueuedItems">({{ filteredItems.length }})</span></span>
+      <span>Queue <span v-if="hasQueuedItems">({{ filteredItems.length }})</span>
+        <span v-if="selectedElms.length > 0">&nbsp;- Selected: {{ selectedElms.length }}</span>
+      </span>
     </span>
   </h1>
 
@@ -22,13 +24,9 @@
         </button>
       </div>
       <div class="column is-half-mobile" v-if="('cards' === display_style || hasSelected)">
-        <button type="button" class="button is-fullwidth is-danger" :disabled="!hasSelected" @click="cancelSelected">
-          <span class="icon-text is-block">
-            <span class="icon">
-              <i class="fa-solid fa-trash-can" />
-            </span>
-            <span>Cancel Selected</span>
-          </span>
+        <button type="button" class="button is-fullwidth is-warning" :disabled="!hasSelected" @click="cancelSelected">
+          <span class="icon"><i class="fa-solid fa-eject" /></span>
+          <span>Cancel</span>
         </button>
       </div>
     </div>
@@ -228,7 +226,7 @@
                       <span class="icon"><i class="fa-solid fa-play" /></span>
                       <span>Play video</span>
                     </NuxtLink>
-                    <hr class="dropdown-divider" v-if="!config.app.basic_mode"/>
+                    <hr class="dropdown-divider" v-if="!config.app.basic_mode" />
                   </template>
 
                   <NuxtLink class="dropdown-item" @click="emitter('getInfo', item.url, item.preset)"

--- a/uv.lock
+++ b/uv.lock
@@ -1408,6 +1408,7 @@ dependencies = [
     { name = "regex" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "yt-dlp" },
+    { name = "zipstream-ng" },
 ]
 
 [package.optional-dependencies]
@@ -1450,5 +1451,15 @@ requires-dist = [
     { name = "regex" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
     { name = "yt-dlp" },
+    { name = "zipstream-ng", specifier = ">=1.8.0" },
 ]
 provides-extras = ["webview"]
+
+[[package]]
+name = "zipstream-ng"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/16/5d9224baf640214255c34a0a0e9528c8403d2b89e2ba7df9d7cada58beb1/zipstream_ng-1.8.0.tar.gz", hash = "sha256:b7129d2c15d26934b3e1cb22256593b6bdbd03c553c26f4199a5bf05110642bc", size = 35887 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/81/11ecdfd5370d6c383f0188a6f2fa2842499e1be617e678d1845f972c6821/zipstream_ng-1.8.0-py3-none-any.whl", hash = "sha256:e7196cb845cf924ed12e7a3b38404ef9e82a5a699801295f5f4cf601449e2bf6", size = 23082 },
+]


### PR DESCRIPTION
This pull request introduces a new feature for downloading selected files as a zip archive, along with UI enhancements and minor bug fixes. The changes span backend API additions, frontend updates for user interaction, and dependency updates.

### Backend Changes:
* Added two new API endpoints in `app/routes/api/browser.py`:
  - [`POST /api/file/download`](diffhunk://#diff-9291aeb95371227de05801931f8aa5a3ccc8752189cf5a55dee87a00d26c6d64R315-R399): Prepares a zip file for download by generating a token and caching file references.
  - [`GET /api/file/download/{token}`](diffhunk://#diff-9291aeb95371227de05801931f8aa5a3ccc8752189cf5a55dee87a00d26c6d64R315-R399): Streams the zip file for download using the token.
* Introduced `zipstream-ng` as a new dependency for streaming zip files. (`pyproject.toml`)

### Frontend Changes:
* Updated `History.vue`:
  - Displayed the count of selected items in the history header.
  - Improved the "Download" button to trigger zip download via the new API and added tooltips for disabled states. [[1]](diffhunk://#diff-d1b0dda75167c1b70eda106d79e4dd55d4bf589f0d1e04925120d8dbb388ad71L25-R40) [[2]](diffhunk://#diff-d1b0dda75167c1b70eda106d79e4dd55d4bf589f0d1e04925120d8dbb388ad71L832-R880)
* Updated `Queue.vue`:
  - Displayed the count of selected items in the queue header.
  - Changed the "Cancel Selected" button styling and icon to better reflect its purpose.

### Bug Fixes:
* Fixed preset validation in `NewDownload.vue` by ensuring `config.isLoaded()` is checked before accessing presets. [[1]](diffhunk://#diff-6fabf4a26fdd84def116eb86bc8e77dfdb1553e7f870592c801a4f7c6dd36097L392-R392) [[2]](diffhunk://#diff-6fabf4a26fdd84def116eb86bc8e77dfdb1553e7f870592c801a4f7c6dd36097L404-R404)