### PR TITLE
correctly upload artifacts

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -6,6 +6,9 @@ on:
       tag:
         required: true
         description: "Ref to build from (e.g. v1.0.0)"
+  push:
+    tags:
+      - "v*"
 
 env:
   PYTHON_VERSION: 3.11
@@ -101,7 +104,7 @@ jobs:
           path: dist/*
 
       - name: Upload to GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.event.inputs.tag, 'v')
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.event.inputs.tag }}

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -10,26 +10,28 @@ on:
     tags:
       - "v*"
 
-env:
-  PYTHON_VERSION: 3.11
-  PNPM_VERSION: 10
-  NODE_VERSION: 20
-
 jobs:
   build:
-    permissions:
-      packages: write
-      contents: write
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+
+    permissions:
+      packages: write
+      contents: write
+
+    env:
+      PYTHON_VERSION: 3.11
+      PNPM_VERSION: 10
+      NODE_VERSION: 20
+      TAG_NAME: ${{ github.event.inputs.tag || github.ref_name }}
 
     steps:
       - name: Checkout source repo
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag }}
+          ref: ${{ env.TAG_NAME }}
 
       - name: Cache Chocolatey packages
         if: matrix.os == 'windows-latest'
@@ -100,14 +102,14 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: app-${{ matrix.os }}-${{ github.event.inputs.tag }}
+          name: app-${{ matrix.os }}-${{ env.TAG_NAME }}
           path: dist/*
 
       - name: Upload to GitHub Release
-        if: startsWith(github.event.inputs.tag, 'v')
+        if: startsWith(env.TAG_NAME, 'v')
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.tag }}
+          tag_name: ${{ env.TAG_NAME }}
           files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/native-build.yml` to improve the handling of tag-based builds and releases. The changes ensure that the workflow triggers appropriately on tag pushes and refines the condition for uploading releases.

### Workflow Trigger Updates:
* Added a `push` event trigger for tags matching the pattern `v*`, enabling the workflow to run automatically when such tags are pushed. (`[.github/workflows/native-build.ymlR9-R11](diffhunk://#diff-2855366f7849d9f8ace8e8e1399ddedcca2b32fc16d7956146a8e4ed59bf5100R9-R11)`)

### Release Upload Condition:
* Updated the condition for the "Upload to GitHub Release" step to check for the tag in `github.event.inputs.tag` instead of `github.ref`, aligning it with the new workflow trigger. (`[.github/workflows/native-build.ymlL104-R107](diffhunk://#diff-2855366f7849d9f8ace8e8e1399ddedcca2b32fc16d7956146a8e4ed59bf5100L104-R107)`)