### PR TITLE
Fix color contrast on pause button in dark mode. Closes #337

### DIFF
--- a/ui/components/Queue.vue
+++ b/ui/components/Queue.vue
@@ -30,7 +30,7 @@
         </button>
       </div>
       <div class="column is-half-mobile" v-if="hasPausable">
-        <button type="button" class="button is-fullwidth is-background-warning-85" :disabled="!hasSelected"
+        <button type="button" class="button is-fullwidth is-warning is-background-warning-85" :disabled="!hasSelected"
           @click="pauseSelected">
           <span class="icon"><i class="fa-solid fa-pause" /></span>
           <span>Pause</span>
@@ -247,7 +247,7 @@
                 </button>
               </div>
               <div class="column is-half-mobile" v-if="item.auto_start && !item.status">
-                <button class="button is-background-warning-85 is-fullwidth" @click="pauseItem(item)">
+                <button class="button is-warning is-background-warning-85 is-fullwidth" @click="pauseItem(item)">
                   <span class="icon"><i class="fa-solid fa-pause" /></span>
                   <span>Pause</span>
                 </button>


### PR DESCRIPTION
This pull request updates button styling in the `Queue.vue` component to improve consistency and adhere to the design system. The changes replace the `is-background-warning-85` class with the `is-warning` class while keeping the former for background styling.

Styling updates:

* Updated the "Pause" button in the `hasPausable` section to include the `is-warning` class for consistent styling. (`ui/components/Queue.vue`, [ui/components/Queue.vueL33-R33](diffhunk://#diff-9c98365b3e09f32cf57fd5b70d4d69f9e9fbf4c1245f1b9ea855fb233f0cf942L33-R33))
* Updated the "Pause" button in the `auto_start` item section to include the `is-warning` class for consistent styling. (`ui/components/Queue.vue`, [ui/components/Queue.vueL250-R250](diffhunk://#diff-9c98365b3e09f32cf57fd5b70d4d69f9e9fbf4c1245f1b9ea855fb233f0cf942L250-R250))