### PR TITLE
add preset name to history/queue

### DIFF
--- a/ui/components/History.vue
+++ b/ui/components/History.vue
@@ -119,14 +119,14 @@
                   </div>
                   <div v-if="showThumbnails && item.extras.thumbnail">
                     <FloatingImage :image="uri('/api/thumbnail?url=' + encodePath(item.extras.thumbnail))"
-                      :title="item.title">
+                      :title="`[${item.preset}] - ${item.title}`">
                       <div class="is-text-overflow">
                         <NuxtLink target="_blank" :href="item.url">{{ item.title }}</NuxtLink>
                       </div>
                     </FloatingImage>
                   </div>
                   <template v-else>
-                    <div class="is-text-overflow" v-tooltip="item.title">
+                    <div class="is-text-overflow" v-tooltip="`[${item.preset}] - ${item.title}`">
                       <NuxtLink target="_blank" :href="item.url">{{ item.title }}</NuxtLink>
                     </div>
                   </template>
@@ -299,6 +299,10 @@
                   <span class="icon" :class="setIconColor(item)"><i :class="[setIcon(item), is_queued(item)]" /></span>
                   <span>{{ setStatus(item) }}</span>
                 </span>
+              </div>
+              <div class="column is-half-mobile has-text-centered is-text-overflow is-unselectable">
+                <span class="icon"><i class="fa-solid fa-sliders" /></span>
+                <span v-tooltip="`Preset: ${item.preset}`" class="user-hint">{{ item.preset }}</span>
               </div>
               <div class="column is-half-mobile has-text-centered is-text-overflow is-unselectable"
                 v-if="'not_live' === item.status && (item.live_in || item.extras?.release_in)">

--- a/ui/components/Queue.vue
+++ b/ui/components/Queue.vue
@@ -118,14 +118,6 @@
                 <td class="is-vcentered is-items-center">
                   <Dropdown icons="fa-solid fa-cogs" @open_state="s => table_container = !s"
                     :button_classes="'is-small'" label="Actions">
-                    <template v-if="!item.auto_start">
-                      <NuxtLink class="dropdown-item has-text-success" @click="startItem(item)">
-                        <span class="icon"><i class="fa-solid fa-circle-play" /></span>
-                        <span>Start Download</span>
-                      </NuxtLink>
-                      <hr class="dropdown-divider" />
-                    </template>
-
                     <template v-if="isEmbedable(item.url)">
                       <NuxtLink class="dropdown-item has-text-danger" @click="embed_url = getEmbedable(item.url)">
                         <span class="icon"><i class="fa-solid fa-play" /></span>
@@ -136,8 +128,24 @@
 
                     <NuxtLink class="dropdown-item has-text-warning" @click="confirmCancel(item);">
                       <span class="icon"><i class="fa-solid fa-eject" /></span>
-                      <span>Cancel Item</span>
+                      <span>Cancel Download</span>
                     </NuxtLink>
+
+                    <template v-if="!item.auto_start && !item.status">
+                      <hr class="dropdown-divider" />
+                      <NuxtLink class="dropdown-item has-text-success" @click="startItem(item)">
+                        <span class="icon"><i class="fa-solid fa-circle-play" /></span>
+                        <span>Start Download</span>
+                      </NuxtLink>
+                    </template>
+
+                    <template v-if="item.auto_start && !item.status">
+                      <hr class="dropdown-divider" />
+                      <NuxtLink class="dropdown-item has-text-warning" @click="pauseItem(item)">
+                        <span class="icon"><i class="fa-solid fa-pause" /></span>
+                        <span>Pause Download</span>
+                      </NuxtLink>
+                    </template>
 
                     <template v-if="!config.app.basic_mode">
                       <hr class="dropdown-divider" />
@@ -222,6 +230,10 @@
                   </span>
                   <span v-text="setStatus(item)" />
                 </span>
+              </div>
+              <div class="column is-half-mobile has-text-centered is-text-overflow is-unselectable">
+                <span class="icon"><i class="fa-solid fa-sliders" /></span>
+                <span v-tooltip="`Preset: ${item.preset}`" class="user-hint">{{ item.preset }}</span>
               </div>
               <div class="column is-half-mobile has-text-centered is-text-overflow is-unselectable">
                 <span v-tooltip="moment(item.datetime).format('MMMM Do YYYY, h:mm:ss a')" :data-datetime="item.datetime"


### PR DESCRIPTION
This pull request introduces enhancements to the UI components `History.vue` and `Queue.vue`, focusing on improving user experience with better contextual information and functionality adjustments. Key updates include displaying preset information, refining tooltips, and reordering dropdown actions for clarity.

### Enhancements to `History.vue`:

* Updated tooltips and titles to include preset information for better context, e.g., `"[preset] - title"` in both the thumbnail and text-overflow areas.
* Added a new column to display the preset associated with each item, with a tooltip for additional clarity.

### Enhancements to `Queue.vue`:

* Reorganized dropdown actions to improve clarity and functionality:
  - Moved the "Start Download" option to appear conditionally based on `auto_start` and `status` properties. [[1]](diffhunk://#diff-9c98365b3e09f32cf57fd5b70d4d69f9e9fbf4c1245f1b9ea855fb233f0cf942L121-L128) [[2]](diffhunk://#diff-9c98365b3e09f32cf57fd5b70d4d69f9e9fbf4c1245f1b9ea855fb233f0cf942L139-R149)
  - Added a new "Pause Download" option for items with `auto_start` enabled but not yet started.
* Updated the "Cancel Item" label to "Cancel Download" for consistency with other actions.
* Added a new column to display preset information with a tooltip, similar to the changes in `History.vue`.