### PR TITLE
Fix playlist_autonumber. Closes #351

### DIFF
--- a/app/library/DownloadQueue.py
+++ b/app/library/DownloadQueue.py
@@ -329,8 +329,8 @@ class DownloadQueue(metaclass=Singleton):
                     "playlist_channel": entry.get("channel"),
                     "playlist_channel_id": entry.get("channel_id"),
                     "playlist_webpage_url": entry.get("webpage_url"),
-                    "playlist_index": f"{{0:0{len(str(playlistCount))}d}}".format(i),
-                    "playlist_autonumber": i + 1,
+                    "playlist_index": i,
+                    "playlist_autonumber": i,
                 }
 
                 for property in ("id", "title", "uploader", "uploader_id"):


### PR DESCRIPTION
This pull request includes a small change to the `async def playlist_processor` function in `app/library/DownloadQueue.py`. The change simplifies the assignment of `playlist_index` and `playlist_autonumber` by directly using the value of `i` instead of applying formatting or incrementing it.