### PR TITLE
Make it possible to pin specific yt-dlp version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,8 @@
     "arrowless",
     "attl",
     "autonumber",
+    "bgutil",
+    "brainicism",
     "brotlicffi",
     "consoletitle",
     "cookiesfrombrowser",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,6 +20,7 @@
     "attl",
     "autonumber",
     "bgutil",
+    "bgutilhttp",
     "brainicism",
     "brotlicffi",
     "consoletitle",
@@ -113,7 +114,8 @@
     "vconvert",
     "writedescription",
     "xerror",
-    "youtu"
+    "youtu",
+    "youtubepot"
   ],
   "css.styleSheets": [
     "ui/app/assets/css/*.css"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONFAULTHANDLER=1
 
 RUN mkdir /config /downloads && ln -snf /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone && \
-  apk add --update --no-cache bash mkvtoolnix patch aria2 coreutils curl shadow sqlite tzdata libmagic ffmpeg rtmpdump fribidi && \
+  apk add --update --no-cache bash mkvtoolnix patch aria2 coreutils curl shadow sqlite tzdata libmagic ffmpeg rtmpdump fribidi git && \
   useradd -u ${USER_ID:-1000} -U -d /app -s /bin/bash app && \
   rm -rf /var/cache/apk/*
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -83,7 +83,17 @@ services:
 Then simply create a new preset, and in the `Command options for yt-dlp` field set the following:
 
 ```bash
---extractor-args "youtubepot-bgutilhttp:base_url=http://bgutil_provider:4416;disable_innertube=1" 
+--extractor-args "youtubepot-bgutilhttp:base_url=http://bgutil_provider:4416" 
 --extractor-args "youtube:player-client=default,tv,mweb;formats=incomplete"
 ```
+
+you and also enable the fallback by using the follow extractor args
+
+```bash
+--extractor-args "youtubepot-bgutilhttp:base_url=http://bgutil_provider:4416;disable_innertube=1"
+--extractor-args "youtube:player-client=default,tv,mweb;formats=incomplete"
+```
+
+Use this settings in case the extractor fails to get the pot tokens from the bgutil provider server.
+
 For more information please visit [bgutil-ytdlp-pot-provider](https://github.com/Brainicism/bgutil-ytdlp-pot-provider) project.

--- a/FAQ.md
+++ b/FAQ.md
@@ -39,3 +39,13 @@ whenever the link includes a playlist id.
 
 > [!NOTE]
 > You can also do the same via advanced options `Command options for yt-dlp` field, but presets are more convenient.
+
+# Install specific yt-dlp version?
+
+You can force specific version of `yt-dlp` by setting the `YTP_YTDLP_VERSION` environment variable for example
+
+```env
+YTP_YTDLP_VERSION=2025.07.21 or master or nightly
+
+Then restart the container to apply the changes.
+

--- a/FAQ.md
+++ b/FAQ.md
@@ -46,6 +46,44 @@ You can force specific version of `yt-dlp` by setting the `YTP_YTDLP_VERSION` en
 
 ```env
 YTP_YTDLP_VERSION=2025.07.21 or master or nightly
+```
 
 Then restart the container to apply the changes.
 
+# How to generate POT tokens?
+
+You need to start up a pot provider server we already have extractor `bgutil-ytdlp-pot-provider` pre-installed in the container.
+You can simply do the following to enable the support for it.
+
+```yaml
+services:
+  ytptube:
+    user: "${UID:-1000}:${UID:-1000}" # change this to your user id and group id, for example: "1000:1000"
+    image: ghcr.io/arabcoders/ytptube:latest
+    container_name: ytptube
+    restart: unless-stopped
+    ports:
+      - "8081:8081"
+    volumes:
+      - ./config:/config:rw
+      - ./downloads:/downloads:rw
+    tmpfs:
+      - /tmp
+    depends_on:
+      - bgutil_provider
+  bgutil_provider:
+    init: true
+    image: brainicism/bgutil-ytdlp-pot-provider:latest
+    container_name: bgutil_provider
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:4416:4416"
+```
+
+Then simply create a new preset, and in the `Command options for yt-dlp` field set the following:
+
+```bash
+--extractor-args "youtubepot-bgutilhttp:base_url=http://bgutil_provider:4416;disable_innertube=1" 
+--extractor-args "youtube:player-client=default,tv,mweb;formats=incomplete"
+```
+For more information please visit [bgutil-ytdlp-pot-provider](https://github.com/Brainicism/bgutil-ytdlp-pot-provider) project.

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ postprocessing, permissions, other `yt-dlp options` configurations which seem no
 concerns the workings of the underlying yt-dlp library, need not be opened on the YTPTube project.
 
 In order to debug and troubleshoot them, it's advised to try using the yt-dlp binary directly first, bypassing the UI, 
-and once that is working, importing the options that worked for you into a new `preset` or `ytdlp.cli` file.
+and once that is working, importing the options that worked for you into a new `preset`.
 
 ## Via HTTP
 
@@ -185,20 +185,6 @@ yt-dlp ....
 ```
 
 Once there, you can use the yt-dlp command freely.
-
-# ytdlp.cli file
-
-The `config/ytdlp.cli`, is a command line options file for `yt-dlp` it will be globally applied to all downloads.
-
-We strongly recommend not use this file for options that aren't **truly global**, everything that can be done via the 
-file can also be done via the presets which is dynamic can be altered per download. Example of good global options 
-are to be used for all downloads are:
-
-```bash
---continue --windows-filenames --live-from-start
-```
-
-Everything else can be done via the presets, and it's more flexible and easier to manage.
 
 # Authentication
 

--- a/README.md
+++ b/README.md
@@ -291,7 +291,6 @@ Certain configuration values can be set via environment variables, using the `-e
 | YTP_TEMP_PATH                  | Path to where tmp files are stored.                                | `/tmp`                             |
 | YTP_TEMP_KEEP                  | Whether to keep the Individual video temp directory or remove it   | `false`                            |
 | YTP_KEEP_ARCHIVE               | Keep history of downloaded videos                                  | `true`                             |
-| YTP_YTDL_DEBUG                 | Whether to turn debug logging for the internal `yt-dlp` package    | `false`                            |
 | YTP_HOST                       | Which IP address to bind to                                        | `0.0.0.0`                          |
 | YTP_PORT                       | Which port to bind to                                              | `8081`                             |
 | YTP_LOG_LEVEL                  | Log level                                                          | `info`                             |
@@ -312,6 +311,8 @@ Certain configuration values can be set via environment variables, using the `-e
 | YTP_BROWSER_ENABLED            | Whether to enable the file browser                                 | `false`                            |
 | YTP_BROWSER_CONTROL_ENABLED    | Whether to enable the file browser actions                         | `false`                            |
 | YTP_YTDLP_AUTO_UPDATE          | Whether to enable the auto update for yt-dlp                       | `true`                             |
+| YTP_YTDLP_DEBUG                | Whether to turn debug logging for the internal `yt-dlp` package    | `false`                            |
+| YTP_YTDLP_VERSION              | The version of yt-dlp to use. Defaults to latest version           | `empty string`                     |
 | YTP_BASE_PATH                  | Set this if you are serving YTPTube from sub-folder                | `/`                                |
 | YTP_PREVENT_LIVE_PREMIERE      | Prevents the initial youtube premiere stream from being downloaded | `false`                            |
 | YTP_TASKS_HANDLER_TIMER        | The cron expression for the tasks handler timer                    | `15 */1 * * *`                     |

--- a/app/library/Download.py
+++ b/app/library/Download.py
@@ -111,7 +111,7 @@ class Download:
         self.info = info
         self.id = info._id
         self.debug = bool(config.debug)
-        self.debug_ytdl = bool(config.ytdl_debug)
+        self.debug_ytdl = bool(config.ytdlp_debug)
         self.cancelled = False
         self.tmpfilename = None
         self.status_queue = None

--- a/app/library/DownloadQueue.py
+++ b/app/library/DownloadQueue.py
@@ -676,7 +676,7 @@ class DownloadQueue(metaclass=Singleton):
                         extract_info,
                         config=yt_conf,
                         url=item.url,
-                        debug=bool(self.config.ytdl_debug),
+                        debug=bool(self.config.ytdlp_debug),
                         no_archive=False,
                         follow_redirect=True,
                     ),

--- a/app/library/config.py
+++ b/app/library/config.py
@@ -46,9 +46,6 @@ class Config:
     keep_archive: bool = True
     """Keep the download archive file."""
 
-    ytdl_debug: bool = False
-    """Enable yt-dlp debugging."""
-
     host: str = "0.0.0.0"
     """The host to bind the server to."""
 
@@ -178,6 +175,12 @@ class Config:
     _ytdlp_cli_mutable: str = ""
     """The command line options to use for yt-dlp."""
 
+    ytdlp_version: str | None = None
+    """The version of yt-dlp to use, if not set, the latest version will be used."""
+
+    ytdlp_debug: bool = False
+    """Enable yt-dlp debugging."""
+
     is_native: bool = False
     "Is the application running in webview."
 
@@ -228,7 +231,7 @@ class Config:
 
     _boolean_vars: tuple = (
         "keep_archive",
-        "ytdl_debug",
+        "ytdlp_debug",
         "debug",
         "temp_keep",
         "access_log",
@@ -531,11 +534,11 @@ class Config:
         if not data.get("keep_archive", False) and ytdlp_args.get("download_archive", None):
             data["keep_archive"] = True
 
-        data["ytdlp_version"] = Config.ytdlp_version()
+        data["ytdlp_version"] = Config._ytdlp_version()
         return data
 
     @staticmethod
-    def ytdlp_version():
+    def _ytdlp_version():
         try:
             from yt_dlp.version import __version__ as YTDLP_VERSION
 

--- a/app/upgrader.py
+++ b/app/upgrader.py
@@ -21,6 +21,8 @@ class Upgrader:
         config_path: Path = Path(__file__).parent.parent / "var" / "config"
         if env_path := os.environ.get("YTP_CONFIG_PATH", None):
             config_path = Path(env_path)
+        else:
+            os.environ.update({"YTP_CONFIG_PATH": str(config_path)})
 
         if config_path.exists():
             envFile: Path = config_path / ".env"
@@ -33,11 +35,17 @@ class Upgrader:
         pkg_installer = PackageInstaller()
 
         ytdlp_auto_update: bool = os.environ.get("YTP_YTDLP_AUTO_UPDATE", "true").strip().lower() == "true"
+        ytdlp_version: str | None = os.environ.get("YTP_YTDLP_VERSION", "").strip() or None
 
         if ytdlp_auto_update:
             try:
                 LOG.info("Checking for newer versions of 'yt-dlp' package.")
-                pkg_installer.action(pkg="yt_dlp", upgrade=True)
+                pkg_name = "yt_dlp"
+                if ytdlp_version:
+                    LOG.info(f"Using specified version '{ytdlp_version}' for '{pkg_name}'.")
+                    pkg_name += f"=={ytdlp_version}"
+
+                pkg_installer.action(pkg=pkg_name, upgrade=True)
 
                 from yt_dlp.version import __version__ as YTDLP_VERSION
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "defusedxml>=0.7.1",
   "zipstream-ng>=1.8.0",
   "apprise>=1.9.3",
+  "bgutil-ytdlp-pot-provider>=1.2.1",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -165,6 +165,15 @@ wheels = [
 ]
 
 [[package]]
+name = "bgutil-ytdlp-pot-provider"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/3f/62fc3c3668a0518cc6a0dab159362bf2c213c0baf7631d15899a98b83176/bgutil_ytdlp_pot_provider-1.2.1.tar.gz", hash = "sha256:771173df631451046c982dcac27482cc89b300ce0aedc487043f80e45774b9f6", size = 8889 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/37/c66e32bdb34b84581b8a794bdc86775b1161208f915f103e39bd1ad665d3/bgutil_ytdlp_pot_provider-1.2.1-py3-none-any.whl", hash = "sha256:ddf9fee9857fb64c7fdfb4db96db81ca5864a6004fff5549a2043693776184ef", size = 9473 },
+]
+
+[[package]]
 name = "bidict"
 version = "0.23.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1575,6 +1584,7 @@ dependencies = [
     { name = "anyio" },
     { name = "apprise" },
     { name = "async-timeout" },
+    { name = "bgutil-ytdlp-pot-provider" },
     { name = "brotli" },
     { name = "brotlicffi" },
     { name = "caribou" },
@@ -1615,6 +1625,7 @@ requires-dist = [
     { name = "anyio" },
     { name = "apprise", specifier = ">=1.9.3" },
     { name = "async-timeout" },
+    { name = "bgutil-ytdlp-pot-provider", specifier = ">=1.2.1" },
     { name = "brotli" },
     { name = "brotlicffi" },
     { name = "caribou", specifier = ">=0.3.0" },


### PR DESCRIPTION
This pull request introduces several enhancements and fixes related to package management, configuration, and documentation, focusing on improved support for specifying yt-dlp versions, better debug configuration, and new features for POT token extraction. It also includes user-facing documentation updates and minor bug fixes.

**Package management and yt-dlp versioning:**

* Added the ability to specify a particular yt-dlp version via the `YTP_YTDLP_VERSION` environment variable, including support for nightly and master builds, and improved version comparison logic in `PackageInstaller` to handle version format differences. [[1]](diffhunk://#diff-c73afc263c8c0971271cfb9462501744c59dfaa0fa260d54dee9c9ae34386cd5L52-R63) [[2]](diffhunk://#diff-c73afc263c8c0971271cfb9462501744c59dfaa0fa260d54dee9c9ae34386cd5L65-R73) [[3]](diffhunk://#diff-c73afc263c8c0971271cfb9462501744c59dfaa0fa260d54dee9c9ae34386cd5L85-R123) [[4]](diffhunk://#diff-c73afc263c8c0971271cfb9462501744c59dfaa0fa260d54dee9c9ae34386cd5R143-R167) [[5]](diffhunk://#diff-0d999fac68fd872ef3303b1dcf0d673eb708fe87dd2a2605903db5f26332a48dR38-R48)
* Updated the Dockerfile to include `git` for installing yt-dlp from source when needed.
* Added `bgutil-ytdlp-pot-provider` as a dependency in `pyproject.toml` for POT token extraction support.

**Configuration and environment variables:**

* Standardized the yt-dlp debug configuration variable to `ytdlp_debug` throughout the codebase and documentation, and exposed new configuration options for yt-dlp version and debug mode. [[1]](diffhunk://#diff-893049a3df17f61c81f3567f90570e5df36ecbedc99b31af3188932866343834L49-L51) [[2]](diffhunk://#diff-893049a3df17f61c81f3567f90570e5df36ecbedc99b31af3188932866343834R178-R183) [[3]](diffhunk://#diff-893049a3df17f61c81f3567f90570e5df36ecbedc99b31af3188932866343834L231-R234) [[4]](diffhunk://#diff-893049a3df17f61c81f3567f90570e5df36ecbedc99b31af3188932866343834L534-R541) [[5]](diffhunk://#diff-c371d628747ee6d313fb7688dc2663db08508b0504ab438c6e8937957bd9bb30L114-R114) [[6]](diffhunk://#diff-e8b7a658e21d8cfe8751ded76ca6956d5061004872c1a3d23b1238cc50387572L679-R679) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L294) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R300-R301)
* Ensured `YTP_CONFIG_PATH` is set in the environment if not already present, improving config file handling.

**Documentation improvements:**

* Updated `README.md` and `FAQ.md` to document how to specify yt-dlp versions, enable debug logging, and configure POT token extraction using `bgutil-ytdlp-pot-provider`, including sample Docker Compose configurations. [[1]](diffhunk://#diff-c7bd425fd98aad1f9fef20099637bcbdcfadeb566ba1f83bb40ce484f195b8cfR42-R99) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L170-R170) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L189-L202)
* Clarified usage of presets over the deprecated `ytdlp.cli` file for yt-dlp options.

**Feature and bug fixes:**

* Enhanced the `/api/history/{id}` endpoint to include ffprobe metadata in the response when available, improving media information visibility. [[1]](diffhunk://#diff-5391f31d117ac9f51ab595d312301bac0f8d2f05a5355e393cbea44d1d250913L73-R75) [[2]](diffhunk://#diff-5391f31d117ac9f51ab595d312301bac0f8d2f05a5355e393cbea44d1d250913R84) [[3]](diffhunk://#diff-5391f31d117ac9f51ab595d312301bac0f8d2f05a5355e393cbea44d1d250913L95-R126)
* Removed unused options from the history dialog in the frontend for a cleaner UI.

**IDE and development environment:**

* Updated `.vscode/settings.json` to include new extractors for improved development experience. [[1]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R22-R24) [[2]](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357L114-R118)