### PR TITLE
fix breaking change to playlist handling.

### DIFF
--- a/app/library/Download.py
+++ b/app/library/Download.py
@@ -292,7 +292,8 @@ class Download:
             if isinstance(self.info_dict, dict) and len(self.info_dict) > 1:
                 self.logger.debug(f"Downloading '{self.info.url}' using pre-info.")
                 _dct: dict = self.info_dict.copy()
-                _dct.update([{k: v for k, v in self.info.extras.items() if k not in _dct or not _dct.get(k)}])
+                if isinstance(self.info.extras, dict) and len(self.info.extras) > 0:
+                    _dct.update({k: v for k, v in self.info.extras.items() if k not in _dct or not _dct.get(k)})
 
                 cls.process_ie_result(ie_result=_dct, download=True)
                 ret: int = cls._download_retcode


### PR DESCRIPTION
This pull request makes a small adjustment to how extra information is merged into the download dictionary in `Download.py`. The change improves robustness by ensuring that the code only attempts to update the dictionary with extras if `self.info.extras` is a non-empty dictionary.

* Added a check to verify that `self.info.extras` is a dictionary and not empty before updating `_dct`, preventing potential errors during the update process.