### PR TITLE
upgrade curl_cffi to 0.13.x

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -74,6 +74,7 @@
     "mult",
     "multidict",
     "muxdelay",
+    "mweb",
     "nodesc",
     "noprogress",
     "onefile",

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,3 +1,105 @@
+# Environment variables
+
+Certain configuration values can be set via environment variables, using the `-e` parameter on the docker command line, 
+or the `environment:` section in `compose.yaml` file.
+
+| Environment Variable           | Description                                                        | Default                            |
+| ------------------------------ | ------------------------------------------------------------------ | ---------------------------------- |
+| YTP_OUTPUT_TEMPLATE            | The template for the filenames of the downloaded videos            | `%(title)s.%(ext)s`                |
+| YTP_DEFAULT_PRESET             | The default preset to use for the download                         | `default`                          |
+| YTP_INSTANCE_TITLE             | The title of the instance                                          | `empty string`                     |
+| YTP_FILE_LOGGING               | Whether to log to file                                             | `false`                            |
+| YTP_DOWNLOAD_PATH              | Path to where the downloads will be saved                          | `/downloads`                       |
+| YTP_MAX_WORKERS                | How many works to use for downloads                                | `1`                                |
+| YTP_AUTH_USERNAME              | Username for basic authentication                                  | `empty string`                     |
+| YTP_AUTH_PASSWORD              | Password for basic authentication                                  | `empty string`                     |
+| YTP_CONSOLE_ENABLED            | Whether to enable the console                                      | `false`                            |
+| YTP_REMOVE_FILES               | Remove the actual file when clicking the remove button             | `false`                            |
+| YTP_CONFIG_PATH                | Path to where the config files will be stored.                     | `/config`                          |
+| YTP_TEMP_PATH                  | Path to where tmp files are stored.                                | `/tmp`                             |
+| YTP_TEMP_KEEP                  | Whether to keep the Individual video temp directory or remove it   | `false`                            |
+| YTP_KEEP_ARCHIVE               | Keep history of downloaded videos                                  | `true`                             |
+| YTP_HOST                       | Which IP address to bind to                                        | `0.0.0.0`                          |
+| YTP_PORT                       | Which port to bind to                                              | `8081`                             |
+| YTP_LOG_LEVEL                  | Log level                                                          | `info`                             |
+| YTP_STREAMER_VCODEC            | The video codec to use for in-browser streaming                    | `libx264`                          |
+| YTP_STREAMER_ACODEC            | The audio codec to use for in-browser streaming                    | `aac`                              |
+| YTP_ACCESS_LOG                 | Whether to log access to the web server                            | `true`                             |
+| YTP_DEBUG                      | Whether to turn on debug mode                                      | `false`                            |
+| YTP_DEBUGPY_PORT               | The port to use for the debugpy debugger                           | `5678`                             |
+| YTP_SOCKET_TIMEOUT             | The timeout for the yt-dlp socket connection variable              | `30`                               |
+| YTP_EXTRACT_INFO_TIMEOUT       | The timeout for extracting video information                       | `70`                               |
+| YTP_DB_FILE                    | The path to the SQLite database file                               | `{config_path}/ytptube.db`         |
+| YTP_MANUAL_ARCHIVE             | The path to the manual archive file                                | `{config_path}/manual_archive.log` |
+| YTP_UI_UPDATE_TITLE            | Whether to update the title of the page with the current stats     | `true`                             |
+| YTP_PIP_PACKAGES               | A space separated list of pip packages to install                  | `empty string`                     |
+| YTP_PIP_IGNORE_UPDATES         | Do not update the custom pip packages                              | `false`                            |
+| YTP_BASIC_MODE                 | Whether to run WebUI in basic mode                                 | `false`                            |
+| YTP_PICTURES_BACKENDS          | A comma separated list of pictures urls to use                     | `empty string`                     |
+| YTP_BROWSER_ENABLED            | Whether to enable the file browser                                 | `false`                            |
+| YTP_BROWSER_CONTROL_ENABLED    | Whether to enable the file browser actions                         | `false`                            |
+| YTP_YTDLP_AUTO_UPDATE          | Whether to enable the auto update for yt-dlp                       | `true`                             |
+| YTP_YTDLP_DEBUG                | Whether to turn debug logging for the internal `yt-dlp` package    | `false`                            |
+| YTP_YTDLP_VERSION              | The version of yt-dlp to use. Defaults to latest version           | `empty string`                     |
+| YTP_BASE_PATH                  | Set this if you are serving YTPTube from sub-folder                | `/`                                |
+| YTP_PREVENT_LIVE_PREMIERE      | Prevents the initial youtube premiere stream from being downloaded | `false`                            |
+| YTP_TASKS_HANDLER_TIMER        | The cron expression for the tasks handler timer                    | `15 */1 * * *`                     |
+| YTP_PLAYLIST_ITEMS_CONCURRENCY | The number of playlist items be to processed at same time          | `1`                                |
+| YTP_TEMP_DISABLED              | Disable temp files handling.                                       | `false`                            |
+| YTP_DOWNLOAD_PATH_DEPTH        | How many subdirectories to show in auto complete.                  | `1`                                |
+
+
+# Browser extensions & bookmarklets
+
+## Simple bookmarklet
+
+```javascript
+javascript:(() => { const url = "https://ytptube.example.org"; const preset = "default"; const mUrl = new URL(url); mUrl.pathname = "/api/history"; fetch(mUrl, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ url: document.location.href, preset: preset }) }).then(res => alert(res.ok ? "URL sent!" : "Failed to send URL.")); })()
+```
+
+Change the the variable `url` and `preset` variables to match your YTPTube instance and preset name.
+
+## Browser stores
+
+- For Firefox via [Firefox Store](https://addons.mozilla.org/en-US/firefox/addon/ytptube-extension/)
+- For Chrome/Chromium Browsers via [Chrome Store](https://chromewebstore.google.com/detail/ytptube-extension/kiepfnpeflemfokokgjiaelddchglfil)
+
+## iOS Shortcuts
+
+You can download [Add To YTPTube](https://www.icloud.com/shortcuts/18b8f70666a04a06aed09424f97ce951) shortcut and use it to send links to your YTPTube instance.
+You have to edit the shortcut and replace the following:
+
+- `https://ytp.example.org` with your YTPTube instance.
+- `username:password` replace this with your own username & password or leave it empty if you don't have authentication enabled.
+
+This shortcut is powerful, as it's allow you to select your preset on the fly pulled directly from your instance.
+Combined with the new and powerful presets system, you could add presets for specific websites that need cookies,
+and use that preset to download directly from your iOS device.
+
+### Advanced iOS Shortcut
+
+This shortcut [YTPTube To Media](https://www.icloud.com/shortcuts/6e3db0bd532843e3aec70e6ce211be08) is more advanced, as it's parses
+the `yt-dlp` output and attempt to download the media directly to your iOS device. It doesn't always work, but it's a good
+starting point for those who want to download media directly to their iOS device. We provide no support for this use case
+other than the shortcut itself. this shortcut missing support for parsing the http_headers, it's only parse the cookies.
+
+
+
+
+
+# Authentication
+
+To enable basic authentication, set the `YTP_AUTH_USERNAME` and `YTP_AUTH_PASSWORD` environment variables. And restart 
+the container. This will prompt the user to enter the username and password before accessing the web interface/API.
+As this is a simple basic authentication, if your browser doesn't show the prompt, you can use the following URL
+
+`http://username:password@your_ytptube_url:port`
+
+# Basic mode
+
+What does the basic mode do? it basically strips down the interface to the bare minimum, 
+to make it easier for non-technical users to use it.
+
 # I cant download anything
 
 If you are receiving errors like:
@@ -52,7 +154,7 @@ Then restart the container to apply the changes.
 
 # How to generate POT tokens?
 
-You need to start up a pot provider server we already have extractor `bgutil-ytdlp-pot-provider` pre-installed in the container.
+You need a pot provider server we already have the extractor `bgutil-ytdlp-pot-provider` pre-installed in the container.
 You can simply do the following to enable the support for it.
 
 ```yaml
@@ -75,9 +177,7 @@ services:
     init: true
     image: brainicism/bgutil-ytdlp-pot-provider:latest
     container_name: bgutil_provider
-    restart: unless-stopped
-    ports:
-      - "127.0.0.1:4416:4416"
+    restart: unless-stopped    
 ```
 
 Then simply create a new preset, and in the `Command options for yt-dlp` field set the following:
@@ -94,6 +194,104 @@ you and also enable the fallback by using the follow extractor args
 --extractor-args "youtube:player-client=default,tv,mweb;formats=incomplete"
 ```
 
-Use this settings in case the extractor fails to get the pot tokens from the bgutil provider server.
-
+Use this alternative extractor args in case the extractor fails to get the pot tokens from the bgutil provider server. 
 For more information please visit [bgutil-ytdlp-pot-provider](https://github.com/Brainicism/bgutil-ytdlp-pot-provider) project.
+
+# How to set global settings for yt-dlp?
+
+You can create a file named `ytdlp.cli` in the `/config` folder, and add your desired global settings there. 
+
+> [!IMPORTANT]
+> We strongly recommend to use presets instead of global settings, as presets are more convenient.
+
+The `ytdlp.cli` file usage is deprecated and likely will be removed in `v1.0.0` release.
+
+# Updating yt-dlp
+
+The engine which powers the actual video downloads in YTPTube is [yt-dlp](https://github.com/yt-dlp/yt-dlp). Since video 
+sites regularly updated, frequent updates of yt-dlp are required to keep up.
+
+We have added the `YTP_YTDLP_AUTO_UPDATE` environment variable, which is enabled by default. This feature allows the 
+container to automatically update `yt-dlp` to the latest version whenever the container starts. If a new version is 
+available, it will be downloaded and applied automatically. To disable this automatic update, set the 
+`YTP_YTDLP_AUTO_UPDATE` environment variable to `false`.
+
+We will no longer release new versions of YTPTube for every new version of yt-dlp.
+
+# Troubleshooting and submitting issues
+
+Before asking a question or submitting an issue for YTPTube, please remember that YTPTube is only a thin wrapper for 
+[yt-dlp](https://github.com/yt-dlp/yt-dlp). Any issues you might be experiencing with authentication to video websites, 
+postprocessing, permissions, other `yt-dlp options` configurations which seem not to work, or anything else that 
+concerns the workings of the underlying yt-dlp library, need not be opened on the YTPTube project.
+
+In order to debug and troubleshoot them, it's advised to try using the yt-dlp binary directly first, bypassing the UI, 
+and once that is working, importing the options that worked for you into a new `preset`.
+
+## Via HTTP
+
+If you have enabled the web terminal via `YTP_CONSOLE_ENABLED` environment variable, simply go to `Other > Terminal` use
+ the yt-dlp command, the interface is jailed to the `yt-dlp` binary you can't access anything else.
+
+## Via CLI 
+
+Assuming your YTPTube container is called `ytptube`, run the following on your docker host to get a shell inside the container:
+
+```bash
+docker exec -ti ytptube bash
+cd /downloads
+yt-dlp ....
+```
+
+Once there, you can use the yt-dlp command freely.
+
+# Run behind reverse proxy.
+
+It's advisable to run YTPTube behind a reverse proxy, if better authentication and/or HTTPS support are required.
+
+## Caddy http server
+
+The following example Caddyfile gets a reverse proxy going behind [caddy](https://caddyserver.com).
+
+```caddyfile
+# If you are using sub-domain.
+# make sure to change "ytptube:8081" to the actual name of your YTPTube container/port.
+ytp.example.org {
+  reverse_proxy ytptube:8081
+}
+
+# If you are using sub-folder, for example: https://example.org/ytptube/
+# Also make sure to set the `YTP_BASE_PATH` environment variable to `/ytptube/`
+# make sure to change "ytptube:8081" to the actual name of your YTPTube container/port.
+example.org {
+  redir /ytptube /ytptube/
+  route /ytptube/* {
+    reverse_proxy ytptube:8081
+  }
+}
+```
+
+# How to autoload yt-dlp plugins?
+
+Loading yt-dlp plugins in YTPTube is quite simple, we already have everything setup for you. simply, create a folder 
+inside the `/config` directory named `yt-dlp` so, the path will be `/config/yt-dlp`. then follow 
+[yt-dlp plugins docs](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#plugins) to know how to install the plugins.
+
+Once you have installed the plugins, restart the container and the plugins will be auto-loaded on demand.
+
+# How to load random backgrounds from WatchState or any other source?
+
+YTPTube can be configured to pull random background images from different sources, including `WatchState` which is another 
+project of mine, simply change the `YTP_PICTURES_BACKENDS` environment variable to the following url
+
+```env
+YTP_PICTURES_BACKENDS=https://watchstate.ip/v1/api/system/images/background?apikey=[api_key]
+```
+
+Where `[api_key]` is the api key you get from your WatchState instance.
+
+# The origin of the project.
+
+The project first started as a fork [meTube](https://github.com/alexta69/metube), since then it has been completely 
+rewritten and redesigned. The original project was a great starting point, but it didn't align with my vision for the 
+project and what i wanted to achieve with it.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ live streams, and includes features like scheduling downloads, sending notificat
 * Custom browser extensions, bookmarklets and iOS shortcuts to send links to YTPTube instance.
 * A executable for Windows, macOS and Linux, which can be found in the release page.
 
+Please read the [FAQ](FAQ.md) for more information.
+
 # Installation
 
 ## Run using docker command
@@ -87,161 +89,9 @@ Then you can access the WebUI at `http://localhost:8081`.
 For `Unraid` users You can install the `Community Applications` plugin, and search for **ytptube** it comes 
 pre-configured.
 
-# Browser extensions & bookmarklets
-
-## Simple bookmarklet
-
-```javascript
-javascript:(() => { const url = "https://ytptube.example.org"; const preset = "default"; const mUrl = new URL(url); mUrl.pathname = "/api/history"; fetch(mUrl, { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ url: document.location.href, preset: preset }) }).then(res => alert(res.ok ? "URL sent!" : "Failed to send URL.")); })()
-```
-
-Change the the variable `url` and `preset` variables to match your YTPTube instance and preset name.
-
-## Browser stores
-
-- For Firefox via [Firefox Store](https://addons.mozilla.org/en-US/firefox/addon/ytptube-extension/)
-- For Chrome/Chromium Browsers via [Chrome Store](https://chromewebstore.google.com/detail/ytptube-extension/kiepfnpeflemfokokgjiaelddchglfil)
-
-## iOS Shortcuts
-
-You can download [Add To YTPTube](https://www.icloud.com/shortcuts/18b8f70666a04a06aed09424f97ce951) shortcut and use it to send links to your YTPTube instance.
-You have to edit the shortcut and replace the following:
-
-- `https://ytp.example.org` with your YTPTube instance.
-- `username:password` replace this with your own username & password or leave it empty if you don't have authentication enabled.
-
-This shortcut is powerful, as it's allow you to select your preset on the fly pulled directly from your instance.
-Combined with the new and powerful presets system, you could add presets for specific websites that need cookies,
-and use that preset to download directly from your iOS device.
-
-### Advanced iOS Shortcut
-
-This shortcut [YTPTube To Media](https://www.icloud.com/shortcuts/6e3db0bd532843e3aec70e6ce211be08) is more advanced, as it's parses
-the `yt-dlp` output and attempt to download the media directly to your iOS device. It doesn't always work, but it's a good
-starting point for those who want to download media directly to their iOS device. We provide no support for this use case
-other than the shortcut itself. this shortcut missing support for parsing the http_headers, it's only parse the cookies.
-
-# Run behind reverse proxy.
-
-It's advisable to run YTPTube behind a reverse proxy, if better authentication and/or HTTPS support are required.
-
-## Caddy http server
-
-The following example Caddyfile gets a reverse proxy going behind [caddy](https://caddyserver.com).
-
-```caddyfile
-# If you are using sub-domain.
-# make sure to change "ytptube:8081" to the actual name of your YTPTube container/port.
-ytp.example.org {
-  reverse_proxy ytptube:8081
-}
-
-# If you are using sub-folder, for example: https://example.org/ytptube/
-# Also make sure to set the `YTP_BASE_PATH` environment variable to `/ytptube/`
-# make sure to change "ytptube:8081" to the actual name of your YTPTube container/port.
-example.org {
-  redir /ytptube /ytptube/
-  route /ytptube/* {
-    reverse_proxy ytptube:8081
-  }
-}
-```
-
-# Updating yt-dlp
-
-The engine which powers the actual video downloads in YTPTube is [yt-dlp](https://github.com/yt-dlp/yt-dlp). Since video 
-sites regularly updated, frequent updates of yt-dlp are required to keep up.
-
-We have added the `YTP_YTDLP_AUTO_UPDATE` environment variable, which is enabled by default. This feature allows the 
-container to automatically update `yt-dlp` to the latest version whenever the container starts. If a new version is 
-available, it will be downloaded and applied automatically. To disable this automatic update, set the 
-`YTP_YTDLP_AUTO_UPDATE` environment variable to `false`.
-
-We will no longer release new versions of YTPTube for every new version of yt-dlp.
-
-# Troubleshooting and submitting issues
-
-Before asking a question or submitting an issue for YTPTube, please remember that YTPTube is only a thin wrapper for 
-[yt-dlp](https://github.com/yt-dlp/yt-dlp). Any issues you might be experiencing with authentication to video websites, 
-postprocessing, permissions, other `yt-dlp options` configurations which seem not to work, or anything else that 
-concerns the workings of the underlying yt-dlp library, need not be opened on the YTPTube project.
-
-In order to debug and troubleshoot them, it's advised to try using the yt-dlp binary directly first, bypassing the UI, 
-and once that is working, importing the options that worked for you into a new `preset`.
-
-## Via HTTP
-
-If you have enabled the web terminal via `YTP_CONSOLE_ENABLED` environment variable, simply go to `Other > Terminal` use
- the yt-dlp command, the interface is jailed to the `yt-dlp` binary you can't access anything else.
-
-## Via CLI 
-
-Assuming your YTPTube container is called `ytptube`, run the following on your docker host to get a shell inside the container:
-
-```bash
-docker exec -ti ytptube bash
-cd /downloads
-yt-dlp ....
-```
-
-Once there, you can use the yt-dlp command freely.
-
-# Authentication
-
-To enable basic authentication, set the `YTP_AUTH_USERNAME` and `YTP_AUTH_PASSWORD` environment variables. And restart 
-the container. This will prompt the user to enter the username and password before accessing the web interface/API.
-As this is a simple basic authentication, if your browser doesn't show the prompt, you can use the following URL
-
-`http://username:password@your_ytptube_url:port`
-
-# Basic mode
-
-What does the basic mode do? it hides the the following features from the WebUI.
-
-### Header
-
-It disables everything except the `settings button` and `reload` button.
-
-### Add form 
-
-* Disable Everything except the `URL` and `Add`.
-* The form will always be visible and un-collapsible.
-* The preset will be the default preset, which can be specified via `YTP_DEFAULT_PRESET` environment variable.
-* The output template will be the default template which can be specified via `YTP_OUTPUT_TEMPLATE` environment variable.
-* The download path will be the default download path which can be specified via `YTP_DOWNLOAD_PATH` environment variable.
-
-### Queue & History
-
-Disables the `Information` button.
-
 # API Documentation
 
 For simple API documentation, you can refer to the [API documentation](API.md).
-
-# How to autoload yt-dlp plugins?
-
-Loading yt-dlp plugins in YTPTube is quite simple, we already have everything setup for you. simply, create a folder 
-inside the `/config` directory named `yt-dlp` so, the path will be `/config/yt-dlp`. then follow 
-[yt-dlp plugins docs](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#plugins) to know how to install the plugins.
-
-Once you have installed the plugins, restart the container and the plugins will be auto-loaded on demand.
-
-# How to load random backgrounds from WatchState or any other source?
-
-YTPTube can be configured to pull random background images from different sources, including `WatchState` which is another 
-project of mine, simply change the `YTP_PICTURES_BACKENDS` environment variable to the following url
-
-```env
-YTP_PICTURES_BACKENDS=https://watchstate.ip/v1/api/system/images/background?apikey=[api_key]
-```
-
-Where `[api_key]` is the api key you get from your WatchState instance.
-
-# The origin of the project.
-
-The project first started as a fork [meTube](https://github.com/alexta69/metube), since then it has been completely 
-rewritten and redesigned. The original project was a great starting point, but it didn't align with my vision for the 
-project and what i wanted to achieve with it.
 
 # Disclaimer
 
@@ -256,53 +106,3 @@ the question. keep in mind it's solo project, as such it might take me a bit of 
 # Donation 
 
 If you feel like donating and appreciate my work, you can do so by donating to children charity. For example [Make-A-Wish](https://worldwish.org). 
-
-# Environment variables
-
-Certain configuration values can be set via environment variables, using the `-e` parameter on the docker command line, or the `environment:` section in `compose.yaml` file.
-
-| Environment Variable           | Description                                                        | Default                            |
-| ------------------------------ | ------------------------------------------------------------------ | ---------------------------------- |
-| YTP_OUTPUT_TEMPLATE            | The template for the filenames of the downloaded videos            | `%(title)s.%(ext)s`                |
-| YTP_DEFAULT_PRESET             | The default preset to use for the download                         | `default`                          |
-| YTP_INSTANCE_TITLE             | The title of the instance                                          | `empty string`                     |
-| YTP_FILE_LOGGING               | Whether to log to file                                             | `false`                            |
-| YTP_DOWNLOAD_PATH              | Path to where the downloads will be saved                          | `/downloads`                       |
-| YTP_MAX_WORKERS                | How many works to use for downloads                                | `1`                                |
-| YTP_AUTH_USERNAME              | Username for basic authentication                                  | `empty string`                     |
-| YTP_AUTH_PASSWORD              | Password for basic authentication                                  | `empty string`                     |
-| YTP_CONSOLE_ENABLED            | Whether to enable the console                                      | `false`                            |
-| YTP_REMOVE_FILES               | Remove the actual file when clicking the remove button             | `false`                            |
-| YTP_CONFIG_PATH                | Path to where the config files will be stored.                     | `/config`                          |
-| YTP_TEMP_PATH                  | Path to where tmp files are stored.                                | `/tmp`                             |
-| YTP_TEMP_KEEP                  | Whether to keep the Individual video temp directory or remove it   | `false`                            |
-| YTP_KEEP_ARCHIVE               | Keep history of downloaded videos                                  | `true`                             |
-| YTP_HOST                       | Which IP address to bind to                                        | `0.0.0.0`                          |
-| YTP_PORT                       | Which port to bind to                                              | `8081`                             |
-| YTP_LOG_LEVEL                  | Log level                                                          | `info`                             |
-| YTP_STREAMER_VCODEC            | The video codec to use for in-browser streaming                    | `libx264`                          |
-| YTP_STREAMER_ACODEC            | The audio codec to use for in-browser streaming                    | `aac`                              |
-| YTP_ACCESS_LOG                 | Whether to log access to the web server                            | `true`                             |
-| YTP_DEBUG                      | Whether to turn on debug mode                                      | `false`                            |
-| YTP_DEBUGPY_PORT               | The port to use for the debugpy debugger                           | `5678`                             |
-| YTP_SOCKET_TIMEOUT             | The timeout for the yt-dlp socket connection variable              | `30`                               |
-| YTP_EXTRACT_INFO_TIMEOUT       | The timeout for extracting video information                       | `70`                               |
-| YTP_DB_FILE                    | The path to the SQLite database file                               | `{config_path}/ytptube.db`         |
-| YTP_MANUAL_ARCHIVE             | The path to the manual archive file                                | `{config_path}/manual_archive.log` |
-| YTP_UI_UPDATE_TITLE            | Whether to update the title of the page with the current stats     | `true`                             |
-| YTP_PIP_PACKAGES               | A space separated list of pip packages to install                  | `empty string`                     |
-| YTP_PIP_IGNORE_UPDATES         | Do not update the custom pip packages                              | `false`                            |
-| YTP_BASIC_MODE                 | Whether to run WebUI in basic mode                                 | `false`                            |
-| YTP_PICTURES_BACKENDS          | A comma separated list of pictures urls to use                     | `empty string`                     |
-| YTP_BROWSER_ENABLED            | Whether to enable the file browser                                 | `false`                            |
-| YTP_BROWSER_CONTROL_ENABLED    | Whether to enable the file browser actions                         | `false`                            |
-| YTP_YTDLP_AUTO_UPDATE          | Whether to enable the auto update for yt-dlp                       | `true`                             |
-| YTP_YTDLP_DEBUG                | Whether to turn debug logging for the internal `yt-dlp` package    | `false`                            |
-| YTP_YTDLP_VERSION              | The version of yt-dlp to use. Defaults to latest version           | `empty string`                     |
-| YTP_BASE_PATH                  | Set this if you are serving YTPTube from sub-folder                | `/`                                |
-| YTP_PREVENT_LIVE_PREMIERE      | Prevents the initial youtube premiere stream from being downloaded | `false`                            |
-| YTP_TASKS_HANDLER_TIMER        | The cron expression for the tasks handler timer                    | `15 */1 * * *`                     |
-| YTP_PLAYLIST_ITEMS_CONCURRENCY | The number of playlist items be to processed at same time          | `1`                                |
-| YTP_TEMP_DISABLED              | Disable temp files handling.                                       | `false`                            |
-| YTP_DOWNLOAD_PATH_DEPTH        | How many subdirectories to show in auto complete.                  | `1`                                |
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # YTPTube
 
 ![Build Status](https://github.com/ArabCoders/ytptube/actions/workflows/main.yml/badge.svg)
+![MIT License](https://img.shields.io/github/license/arabcoders/ytptube.svg)
+![Docker pull](https://ghcr-badge.elias.eu.org/shield/arabcoders/ytptube/ytptube)
 
 **YTPTube** is a web-based GUI for [yt-dlp](https://github.com/yt-dlp/yt-dlp), designed to make downloading videos from 
 YouTube and other video platforms easier and more user-friendly. It supports downloading playlists, channels, and 
@@ -10,28 +12,24 @@ live streams, and includes features like scheduling downloads, sending notificat
 
 # YTPTube Features.
 
-* Multi-downloads support.
-* Random beautiful background. `can be disabled or source changed`.
-* Can handle live streams.
-* Scheduler to queue channels or playlists to be downloaded automatically at a specified time.
-* Send notification to targets based on selected events. includes [Apprise](https://github.com/caronc/apprise?tab=readme-ov-file#readme) support for non http/https URLs.
-* Support per link `cli options` & `cookies`.
-* Queue multiple URLs separated by comma.
-* Presets system to re-use frequently used yt-dlp options.
-* Simple file browser. `Disabled by default`.
+* Multi-download support.
+* Random beautiful background.
+* Handles live and upcoming streams.
+* Schedule channels or playlists to be downloaded automatically.
+* Send notification to targets based on selected events. includes [Apprise](https://github.com/caronc/apprise?tab=readme-ov-file#readme) support.
+* Support per link options.
+* Queue multiple URLs.
+* Powerful presets system for applying `yt-dlp` options.
+* File browser.
 * A built in video player **with support for sidecar external subtitles**.
-* New `POST /api/history` endpoint that allow one or multiple links to be sent at the same time.
-* New `GET /api/history/add?url=http://..` endpoint that allow to add single item via GET request.
-* Modern frontend UI.
-* SQLite as database backend.
 * Basic authentication support.
-* Support for curl_cffi, see [yt-dlp documentation](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#impersonation)
-* Support basic mode for WebUI for non-technical users, which hides most of the normal features from view.
-* Bundled tools in container: curl-cffi, ffmpeg, ffprobe, aria2, rtmpdump, mkvtoolsnix, mp4box.
-* Automatic upcoming live stream re-queue.
-* Apply `yt-dlp` options per custom defined conditions.
+* Supports `curl-cffi`. See [yt-dlp documentation](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#impersonation)
+* Bundled `pot provider`. See [yt-dlp documentation](https://github.com/yt-dlp/yt-dlp/wiki/PO-Token-Guide)
+* Automatic updates for `yt-dlp` and custom `pip` packages.
+* Basic mode UI for non-technical users.
+* Conditions feature.
 * Custom browser extensions, bookmarklets and iOS shortcuts to send links to YTPTube instance.
-* A executable for Windows, macOS and Linux, which can be found in the release page.
+* A Bundled executable version for Windows, macOS and Linux.
 
 Please read the [FAQ](FAQ.md) for more information.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "httpx",
   "async-timeout",
   "pyjson5",
-  "curl_cffi==0.7.1",
+  "curl_cffi>=0.13",
   "pysubs2",
   "regex",
   "mutagen",

--- a/ui/package.json
+++ b/ui/package.json
@@ -28,5 +28,11 @@
     "vue": "^3.5.19",
     "vue-router": "^4.5.1",
     "vue-toastification": "2.0.0-rc.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "@parcel/watcher"
+    ]
   }
 }

--- a/uv.lock
+++ b/uv.lock
@@ -434,23 +434,23 @@ wheels = [
 
 [[package]]
 name = "curl-cffi"
-version = "0.7.1"
+version = "0.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "cffi" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/31/00b346537ece64d835fc5d7310f89acee5318fdd9fa72247913274e28817/curl_cffi-0.7.1.tar.gz", hash = "sha256:8a64b12432146a3f178c4792c91188c18f50cc4b76e908ffc3206442c4610894", size = 133179 }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/3d/f39ca1f8fdf14408888e7c25e15eed63eac5f47926e206fb93300d28378c/curl_cffi-0.13.0.tar.gz", hash = "sha256:62ecd90a382bd5023750e3606e0aa7cb1a3a8ba41c14270b8e5e149ebf72c5ca", size = 151303 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/11/0be8b95d21dc34811c68c45ab382ed20dfbfb4cbc8899f732d8b04651fd9/curl_cffi-0.7.1-cp38-abi3-macosx_10_9_x86_64.whl", hash = "sha256:54edae42b25f30048fd6c2de06ed9df37bbe6ffdce14cc8a27c79f8c7d47977a", size = 5101433 },
-    { url = "https://files.pythonhosted.org/packages/78/67/8dd0c86435a3a7860fafbd72d572498e89a2ccc5ac2654bd3ebd26eecbb1/curl_cffi-0.7.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:5c347e221ddbbde2275aa7cde00933402638c2062a3984104f66b1bb20528545", size = 2482887 },
-    { url = "https://files.pythonhosted.org/packages/ae/61/8015cfcfdd7487f2cfeca90a18fd5504d29192b4700af93494d6915f508d/curl_cffi-0.7.1-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:99a5cc1d9ca59692cc5c175da0b397104283a0fea7515045fd22a7296296d82b", size = 5712868 },
-    { url = "https://files.pythonhosted.org/packages/d2/d5/0569f453994c94901e85392e72a5df268646e8f19b829a8c807ddd3b996f/curl_cffi-0.7.1-cp38-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0719fec4b5e1c300bf58411b1cea26cb91c44492fcf5a14ef684fe085f4d8b6e", size = 5518309 },
-    { url = "https://files.pythonhosted.org/packages/25/25/56cbb1fc9cff46999a11ccb75dab1ee62be629d6e871142c37d26ed460d7/curl_cffi-0.7.1-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1e53ab76259b575017d3260854456ba6a3fbe31cee9b44edd275d4ea9f0f20e1", size = 6073331 },
-    { url = "https://files.pythonhosted.org/packages/49/68/66b047ee7664554d97adc3e4f566d7afcaf57a8d5979508002eecea0da09/curl_cffi-0.7.1-cp38-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:39d04ee1fc5f668ce53234051153031b3a3714300b772379e276565ad7cd244c", size = 6218360 },
-    { url = "https://files.pythonhosted.org/packages/56/08/3d03b147545cb14f4d1dfe24a581d6671522e465586fc57efeec4f9e5807/curl_cffi-0.7.1-cp38-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:e60f0dca3a55298898c62c21f0d8461e61aab96d033a7e9cead6160462728f7f", size = 6001290 },
-    { url = "https://files.pythonhosted.org/packages/1c/ca/d98b79b6599c3f217cd87f5974f57f9eb472dfb27d80eca3cf6b9040cc4e/curl_cffi-0.7.1-cp38-abi3-win32.whl", hash = "sha256:318a9a21f69e720ca904a0edc80bcbb7bbb75a4bab7b31341a202f07d5378c8e", size = 4184853 },
-    { url = "https://files.pythonhosted.org/packages/cb/16/773159bbac84807f0be78d19b832f109bf8bd46f0bc2d79a21849d0c385f/curl_cffi-0.7.1-cp38-abi3-win_amd64.whl", hash = "sha256:0eb5b08f562749639529e6990ff1b10a40e53ed45115e15f00b239230eabb927", size = 3990082 },
+    { url = "https://files.pythonhosted.org/packages/19/d1/acabfd460f1de26cad882e5ef344d9adde1507034528cb6f5698a2e6a2f1/curl_cffi-0.13.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:434cadbe8df2f08b2fc2c16dff2779fb40b984af99c06aa700af898e185bb9db", size = 5686337 },
+    { url = "https://files.pythonhosted.org/packages/2c/1c/cdb4fb2d16a0e9de068e0e5bc02094e105ce58a687ff30b4c6f88e25a057/curl_cffi-0.13.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:59afa877a9ae09efa04646a7d068eeea48915a95d9add0a29854e7781679fcd7", size = 2994613 },
+    { url = "https://files.pythonhosted.org/packages/04/3e/fdf617c1ec18c3038b77065d484d7517bb30f8fb8847224eb1f601a4e8bc/curl_cffi-0.13.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d06ed389e45a7ca97b17c275dbedd3d6524560270e675c720e93a2018a766076", size = 7931353 },
+    { url = "https://files.pythonhosted.org/packages/3d/10/6f30c05d251cf03ddc2b9fd19880f3cab8c193255e733444a2df03b18944/curl_cffi-0.13.0-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b4e0de45ab3b7a835c72bd53640c2347415111b43421b5c7a1a0b18deae2e541", size = 7486378 },
+    { url = "https://files.pythonhosted.org/packages/77/81/5bdb7dd0d669a817397b2e92193559bf66c3807f5848a48ad10cf02bf6c7/curl_cffi-0.13.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8eb4083371bbb94e9470d782de235fb5268bf43520de020c9e5e6be8f395443f", size = 8328585 },
+    { url = "https://files.pythonhosted.org/packages/ce/c1/df5c6b4cfad41c08442e0f727e449f4fb5a05f8aa564d1acac29062e9e8e/curl_cffi-0.13.0-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:28911b526e8cd4aa0e5e38401bfe6887e8093907272f1f67ca22e6beb2933a51", size = 8739831 },
+    { url = "https://files.pythonhosted.org/packages/1a/91/6dd1910a212f2e8eafe57877bcf97748eb24849e1511a266687546066b8a/curl_cffi-0.13.0-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:6d433ffcb455ab01dd0d7bde47109083aa38b59863aa183d29c668ae4c96bf8e", size = 8711908 },
+    { url = "https://files.pythonhosted.org/packages/6d/e4/15a253f9b4bf8d008c31e176c162d2704a7e0c5e24d35942f759df107b68/curl_cffi-0.13.0-cp39-abi3-win_amd64.whl", hash = "sha256:66a6b75ce971de9af64f1b6812e275f60b88880577bac47ef1fa19694fa21cd3", size = 1614510 },
+    { url = "https://files.pythonhosted.org/packages/f9/0f/9c5275f17ad6ff5be70edb8e0120fdc184a658c9577ca426d4230f654beb/curl_cffi-0.13.0-cp39-abi3-win_arm64.whl", hash = "sha256:d438a3b45244e874794bc4081dc1e356d2bb926dcc7021e5a8fef2e2105ef1d8", size = 1365753 },
 ]
 
 [[package]]
@@ -1635,7 +1635,7 @@ requires-dist = [
     { name = "brotlicffi" },
     { name = "caribou", specifier = ">=0.3.0" },
     { name = "coloredlogs", specifier = ">=15.0.1" },
-    { name = "curl-cffi", specifier = "==0.7.1" },
+    { name = "curl-cffi", specifier = ">=0.13" },
     { name = "dateparser", specifier = ">=1.2.1" },
     { name = "debugpy", specifier = ">=1.8.1" },
     { name = "defusedxml", specifier = ">=0.7.1" },


### PR DESCRIPTION
This pull request introduces several documentation improvements and minor configuration changes, focusing on enhancing user guidance for environment variables, browser integrations, authentication, troubleshooting, and reverse proxy setup. The changes also clarify feature descriptions and update badges in the `README.md` for better visibility.

**Documentation improvements:**

* Added a comprehensive section to `FAQ.md` detailing all supported environment variables, their descriptions, and defaults, making it easier for users to configure the application.
* Expanded `FAQ.md` with instructions for browser bookmarklets, browser store extensions, and iOS shortcuts, providing users with multiple ways to send URLs to their YTPTube instance.
* Included detailed setup guidance in `FAQ.md` for authentication, basic mode, troubleshooting, submitting issues, running behind a reverse proxy (including Caddy server configuration), autoloading yt-dlp plugins, and loading random backgrounds from external sources.
* Updated the troubleshooting section in `FAQ.md` to clarify the relationship between YTPTube and yt-dlp, and added instructions for debugging via HTTP and CLI.

**Feature and configuration clarifications:**

* Improved the `README.md` feature list for clarity and conciseness, highlighting key features and referencing the FAQ for further details.
* Added MIT License and Docker pull badges to the top of `README.md` for better project visibility.

**Minor configuration changes:**

* Added `"mweb"` to the Python auto-complete list in `.vscode/settings.json`.
* Updated instructions in `FAQ.md` for setting up the pot provider server and extractor args, and clarified port configuration guidance. [[1]](diffhunk://#diff-c7bd425fd98aad1f9fef20099637bcbdcfadeb566ba1f83bb40ce484f195b8cfL55-R157) [[2]](diffhunk://#diff-c7bd425fd98aad1f9fef20099637bcbdcfadeb566ba1f83bb40ce484f195b8cfL79-L80) [[3]](diffhunk://#diff-c7bd425fd98aad1f9fef20099637bcbdcfadeb566ba1f83bb40ce484f195b8cfL97-R297)