### PR TITLE
Fix native builds.

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -42,16 +42,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.TAG_NAME }}
-
-      - name: Cache Chocolatey packages
-        if: matrix.os == 'windows-latest'
-        uses: actions/cache@v4
-        with:
-          path: C:\ProgramData\chocolatey\lib
-          key: choco-${{ runner.os }}-${{ matrix.arch }}-qt6
-          restore-keys: |
-            choco-${{ runner.os }}-${{ matrix.arch }}-
-
       - name: Cache Python venv
         id: cache-python
         uses: actions/cache@v4
@@ -71,7 +61,7 @@ jobs:
         run: |
           pip install uv
           uv venv --system-site-packages --relocatable
-          uv sync --link-mode=copy --active
+          uv sync --link-mode=copy --active -extra installer
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -93,7 +83,7 @@ jobs:
 
       - name: Build native binary
         run: |
-          uv tool run pyinstaller ./app.spec
+          uv run pyinstaller ./app.spec
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for native builds, primarily focusing on simplifying caching and improving Python dependency management. The most important changes are grouped below:

Caching changes:

* Removed the step that caches Chocolatey packages for Windows builds, reducing complexity and potential cache issues in the workflow.

Python environment and dependency management:

* Updated the `uv sync` command to include the `-extra installer` flag, ensuring that installer-related dependencies are properly installed in the Python environment.
* Changed the command used to run `pyinstaller` from `uv tool run` to `uv run`, which is the recommended usage and may improve reliability and compatibility.