### PR TITLE
Implement a workaround for slowness in status update

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -48,7 +48,7 @@ jobs:
           ref: ${{ env.TAG_NAME }}
 
       - name: Overwrite app.spec from workflow branch
-        if: github.event.inputs.useWorkflowSpec == true
+        if: ${{ github.event.inputs.useWorkflowSpec == 'true' }}
         uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
@@ -58,7 +58,7 @@ jobs:
           path: temp-spec
 
       - name: Replace app.spec with version from workflow branch
-        if: github.event.inputs.useWorkflowSpec == true
+        if: ${{ github.event.inputs.useWorkflowSpec == 'true' }}
         run: cp temp-spec/app.spec ./app.spec
 
       - name: Cache Python venv

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -6,6 +6,10 @@ on:
       tag:
         required: true
         description: "Ref to build from (e.g. v1.0.0)"
+      useWorkflowSpec:
+        type: boolean
+        default: false
+        description: "Use app.spec from workflow branch instead of tag"
   push:
     tags:
       - "v*"
@@ -42,6 +46,21 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.TAG_NAME }}
+
+      - name: Overwrite app.spec from workflow branch
+        if: github.event.inputs.useWorkflowSpec == true
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          sparse-checkout: |
+            app.spec
+          sparse-checkout-cone-mode: false
+          path: temp-spec
+
+      - name: Replace app.spec with version from workflow branch
+        if: github.event.inputs.useWorkflowSpec == true
+        run: cp temp-spec/app.spec ./app.spec
+
       - name: Cache Python venv
         id: cache-python
         uses: actions/cache@v4

--- a/app/library/DownloadQueue.py
+++ b/app/library/DownloadQueue.py
@@ -981,6 +981,8 @@ class DownloadQueue(metaclass=Singleton):
             await entry.start()
 
             if entry.info.status not in ("finished", "skip"):
+                if not entry.info.error:
+                    entry.info.error = f"Download failed with status '{entry.info.status}'."
                 entry.info.status = "error"
         except Exception as e:
             entry.info.status = "error"


### PR DESCRIPTION
When the event loop becomes congested with many coroutines, important events can sometimes be delayed or arrive out of order. This can cause items to be incorrectly marked as failed and errors shown to the user. Unfortunately, there’s no clean way around this without introducing a targeted workaround.

Our approach is as follows: once a download finishes, we attempt to drain the status update queue. If we receive the final update, we stop immediately. If a timeout occurs before the final update arrives, we mark the item as failed.

This solution has no impact on normal downloads. It specifically addresses edge cases where large numbers of very small items are queued. In those situations, downloads can complete so quickly that the event queue cannot drain fast enough, and this mechanism ensures correctness despite that bottleneck.

===================

This pull request introduces improvements to the download status tracking and notification logic, refactors hooks for clarity, and adds an option to the native build workflow for more flexible spec handling. The most important changes are grouped below.

**Download status tracking and notification logic:**

* Refactored the `progress_update` logic in `Download.py` by introducing a `_process_status_update` method to handle status updates more robustly, including proper handling of final file names, relative paths, and marking the final update state. This ensures more accurate and reliable notifications and file status updates. [[1]](diffhunk://#diff-c371d628747ee6d313fb7688dc2663db08508b0504ab438c6e8937957bd9bb30L483-R543) [[2]](diffhunk://#diff-c371d628747ee6d313fb7688dc2663db08508b0504ab438c6e8937957bd9bb30L356-R387)
* Improved hook methods (`_progress_hook` and `_postprocessor_hook`) to use deep copies for debug logging, include an `action` field in status messages, and provide clearer separation between progress, postprocessing, and moved actions.
* Enhanced error handling in `DownloadQueue.py` to set a default error message if a download fails without an explicit error, making failures easier to diagnose.

**Native build workflow enhancements:**

* Added a `useWorkflowSpec` input to the native build GitHub Actions workflow, allowing the workflow to optionally use the `app.spec` file from the workflow branch instead of the tag. This provides more flexibility for testing and building from different branches.
* Implemented steps in the workflow to conditionally overwrite and replace the `app.spec` file based on the new input, ensuring the correct spec file is used during the build process.

These changes improve the reliability of download status updates, provide clearer debug information, and add useful flexibility to the build workflow.