### PR TITLE
FEAT: Make it possible to limit notify target to specific presets.

### DIFF
--- a/app/library/Tasks.py
+++ b/app/library/Tasks.py
@@ -434,13 +434,13 @@ class Tasks(metaclass=Singleton):
             _tasks = [
                 self._notify.emit(
                     Events.TASK_DISPATCHED,
-                    data=status,
+                    data={**status, "preset": task.preset} if status else {"preset": task.preset},
                     title=f"Task '{task.name}' dispatched",
                     message=f"Task '{task.name}' dispatched at '{timeNow}'.",
                 ),
                 self._notify.emit(
                     Events.LOG_SUCCESS,
-                    data={"lowPriority": True},
+                    data={"preset": task.preset, "lowPriority": True},
                     title="Task completed",
                     message=f"Task '{task.name}' completed in '{ended - started:.2f}'.",
                 ),
@@ -451,6 +451,7 @@ class Tasks(metaclass=Singleton):
             LOG.error(f"Failed to execute '{task.name}' at '{timeNow}'. '{e!s}'.")
             await self._notify.emit(
                 Events.LOG_ERROR,
+                data={"preset": task.preset},
                 title="Task failed",
                 message=f"Failed to execute '{task.name}'. '{e!s}'",
             )

--- a/app/routes/socket/history.py
+++ b/app/routes/socket/history.py
@@ -15,18 +15,21 @@ async def add_url(queue: DownloadQueue, notify: EventBus, sid: str, data: dict):
         await notify.emit(Events.LOG_ERROR, title="Invalid request", message="No URL provided.", to=sid)
         return
 
+    item: Item = Item.format(data)
     try:
-        status = await queue.add(item=Item.format(data))
+        status = await queue.add(item=item)
         await notify.emit(
             event=Events.ITEM_STATUS,
             title="Adding URL",
             message=f"Adding URL '{url}' to the download queue.",
-            data=status,
+            data={**status, "preset": item.preset} if status else {"preset": item.preset},
             to=sid,
         )
     except ValueError as e:
         LOG.exception(e)
-        await notify.emit(Events.LOG_ERROR, title="Error Adding URL", message=str(e), to=sid)
+        await notify.emit(
+            Events.LOG_ERROR, data={"preset": item.preset}, title="Error Adding URL", message=str(e), to=sid
+        )
 
 
 @route(RouteType.SOCKET, "item_cancel", "item_cancel")

--- a/ui/app/components/NotificationForm.vue
+++ b/ui/app/components/NotificationForm.vue
@@ -48,7 +48,7 @@
                     </button>
                   </div>
                 </div>
-                <span class="help">
+                <span class="help is-bold">
                   <span class="icon"><i class="fa-solid fa-info" /></span>
                   <span>You can use this field to populate the data, using shared string.</span>
                 </span>
@@ -63,7 +63,7 @@
                     <input type="text" class="input" id="name" v-model="form.name" :disabled="addInProgress" required>
                     <span class="icon is-small is-left"><i class="fa-solid fa-user" /></span>
                   </div>
-                  <span class="help">
+                  <span class="help is-bold">
                     <span class="icon"><i class="fa-solid fa-info" /></span>
                     <span>The notification target name, this is used to identify the target in the logs and
                       notifications.</span>
@@ -81,11 +81,13 @@
                       required>
                     <span class="icon is-small is-left"><i class="fa-solid fa-link" /></span>
                   </div>
-                  <span class="help">
+                  <span class="help is-bold">
                     <span class="icon"><i class="fa-solid fa-info" /></span>
-                    <span class="is-bold">The URL to send the notification to. It can be regular http/https endpoint.
-                      or <NuxtLink target="blank" href="https://github.com/caronc/apprise?tab=readme-ov-file#readme">
-                        Apprise</NuxtLink> URL.</span>
+                    <span>
+                      The URL to send the notification to. It can be regular http/https endpoint. or <NuxtLink
+                        target="blank" href="https://github.com/caronc/apprise?tab=readme-ov-file#readme">Apprise
+                      </NuxtLink> URL.
+                    </span>
                   </span>
                 </div>
               </div>
@@ -105,7 +107,7 @@
                     </div>
                     <span class="icon is-small is-left"><i class="fa-solid fa-tv" /></span>
                   </div>
-                  <span class="help">
+                  <span class="help is-bold">
                     <span class="icon"><i class="fa-solid fa-info" /></span>
                     <span>
                       The request method to use when sending the notification. This can be any of the standard HTTP
@@ -130,7 +132,7 @@
                     </div>
                     <span class="icon is-small is-left"><i class="fa-solid fa-tv" /></span>
                   </div>
-                  <span class="help">
+                  <span class="help is-bold">
                     <span class="icon"><i class="fa-solid fa-info" /></span>
                     <span>
                       The request type to use when sending the notification. This can be <code>JSON</code> or
@@ -140,7 +142,7 @@
                 </div>
               </div>
 
-              <div class="column is-12-mobile" :class="{ 'is-6-tablet': !isApprise, 'is-12': isApprise }">
+              <div class="column is-6-tablet is-12-mobile">
                 <div class="field">
                   <label class="label is-inline" for="on">
                     Select Events
@@ -158,7 +160,7 @@
                     </div>
                     <span class="icon is-small is-left"><i class="fa-solid fa-paper-plane" /></span>
                   </div>
-                  <span class="help">
+                  <span class="help is-bold">
                     <span class="icon"><i class="fa-solid fa-info" /></span>
                     <span>
                       Subscribe to the events you want to listen for. When the event is triggered, the notification will
@@ -169,7 +171,43 @@
                 </div>
               </div>
 
-              <div class="column is-6-tablet is-12-mobile" v-if="!isApprise">
+              <div class="column is-6-tablet is-12-mobile">
+                <div class="field">
+                  <label class="label is-inline" for="on">
+                    Select Presets
+                    <template v-if="form.presets.length > 0">
+                      - <NuxtLink @click="form.presets = []">Clear selection</NuxtLink>
+                    </template>
+                  </label>
+                  <div class="control has-icons-left">
+                    <div class="select is-multiple is-fullwidth">
+                      <select id="on" class="is-fullwidth" v-model="form.presets" :disabled="addInProgress" multiple>
+                        <optgroup label="Custom presets" v-if="config?.presets.filter(p => !p?.default).length > 0">
+                          <option v-for="item in filter_presets(false)" :key="item.id" :value="item.name">
+                            {{ item.name }}
+                          </option>
+                        </optgroup>
+                        <optgroup label="Default presets">
+                          <option v-for="item in filter_presets(true)" :key="item.id" :value="item.name">
+                            {{ item.name }}
+                          </option>
+                        </optgroup>
+                      </select>
+                    </div>
+                    <span class="icon is-small is-left"><i class="fa-solid fa-sliders" /></span>
+                  </div>
+                  <span class="help is-bold">
+                    <span class="icon"><i class="fa-solid fa-info" /></span>
+                    <span>
+                      Select the presets you want to listen for. If you select presets, only events that reference those
+                      presets will trigger the notification. If no presets are selected, the notification will be sent
+                      for all presets.
+                    </span>
+                  </span>
+                </div>
+              </div>
+
+              <div class="column is-12" v-if="!isApprise">
                 <div class="field">
                   <label class="label is-inline" for="data_key">
                     Data field
@@ -179,7 +217,7 @@
                       :disabled="addInProgress" required>
                     <span class="icon is-small is-left"><i class="fa-solid fa-key" /></span>
                   </div>
-                  <span class="help">
+                  <span class="help is-bold">
                     <span class="icon"><i class="fa-solid fa-info" /></span>
                     <span>
                       The field name to use when sending the notification. This is used to identify the data in the
@@ -206,7 +244,7 @@
                             <span class="icon is-small is-left"><i class="fa-solid fa-key" /></span>
                           </div>
                         </div>
-                        <span class="help">
+                        <span class="help is-bold">
                           <span class="icon"><i class="fa-solid fa-info" /></span>
                           <span>The header key to send with the notification.</span>
                         </span>
@@ -219,7 +257,7 @@
                             <span class="icon is-small is-left"><i class="fa-solid fa-v" /></span>
                           </div>
                         </div>
-                        <span class="help">
+                        <span class="help is-bold">
                           <span class="icon"><i class="fa-solid fa-info" /></span>
                           <span>The header value to send with the notification.</span>
                         </span>
@@ -234,7 +272,7 @@
                       </div>
                     </template>
                   </div>
-                  <span class="help">
+                  <span class="help is-bold">
                     <span class="icon"><i class="fa-solid fa-exclamation" /></span>
                     <span class="has-text-danger">
                       If header key or value is empty, the header will not be sent.
@@ -274,6 +312,7 @@ import type { notification, notificationImport } from '~/types/notification'
 const emitter = defineEmits(['cancel', 'submit'])
 const toast = useNotification()
 const box = useConfirm()
+const config = useConfigStore()
 
 const props = defineProps({
   reference: {
@@ -396,7 +435,17 @@ const importItem = async () => {
 
     if (item.on) {
       form.on = item.on
+    }
 
+    if (item.presets) {
+      item.presets.forEach(p => {
+        if (!config.presets.find(cp => cp.name === p)) {
+          return
+        }
+        if (!form.presets.includes(p)) {
+          form.presets.push(p)
+        }
+      })
     }
 
     import_string.value = ''
@@ -407,4 +456,5 @@ const importItem = async () => {
 }
 
 const isApprise = computed(() => form.request.url && !form.request.url.startsWith('http'))
+const filter_presets = (flag: boolean = true) => config.presets.filter(item => item.default === flag)
 </script>

--- a/ui/app/types/notification.d.ts
+++ b/ui/app/types/notification.d.ts
@@ -15,7 +15,8 @@ type notification = {
   id?: string;
   name: string;
   request: notificationRequest;
-  on: string[];
+  on: Array<string>;
+  presets: Array<string>;
   raw?: boolean;
 };
 


### PR DESCRIPTION
This pull request introduces support for notification targeting by preset, refactors notification data handling to consistently include preset information, and improves validation logic for notification targets. Additionally, minor UI improvements are made to the notification form. These changes enhance the flexibility and accuracy of notification delivery, ensuring notifications can be filtered and dispatched based on preset associations.

**Notification system enhancements:**

* Added support for associating notification targets with specific presets by introducing a `presets` field to the `Target` class and serialization logic in `Notifications.py`. Notification delivery now checks if the event's preset matches the target's presets before sending. (F4020f95L72R72, [[1]](diffhunk://#diff-675938cb2bd2cad7b4782c9c024db9492a126e77a3691bf6fa5d5f0ce0f67ad0R261) [[2]](diffhunk://#diff-675938cb2bd2cad7b4782c9c024db9492a126e77a3691bf6fa5d5f0ce0f67ad0R336-R353) [[3]](diffhunk://#diff-675938cb2bd2cad7b4782c9c024db9492a126e77a3691bf6fa5d5f0ce0f67ad0R385-R387) [[4]](diffhunk://#diff-675938cb2bd2cad7b4782c9c024db9492a126e77a3691bf6fa5d5f0ce0f67ad0R401-R423)
* Improved validation for notification targets to ensure the `presets` field is a valid list and contains only recognized preset names. Invalid presets are removed, and an error is raised if none remain.

**Consistent inclusion of preset information in notifications:**

* Updated all notification emit calls in `DownloadQueue.py`, `Tasks.py`, and `history.py` to include the `preset` field in the `data` payload, ensuring downstream consumers (such as notification targets) can filter or process events by preset. [[1]](diffhunk://#diff-e8b7a658e21d8cfe8751ded76ca6956d5061004872c1a3d23b1238cc50387572L497-R502) [[2]](diffhunk://#diff-e8b7a658e21d8cfe8751ded76ca6956d5061004872c1a3d23b1238cc50387572L514-R524) [[3]](diffhunk://#diff-e8b7a658e21d8cfe8751ded76ca6956d5061004872c1a3d23b1238cc50387572L549-R561) [[4]](diffhunk://#diff-e8b7a658e21d8cfe8751ded76ca6956d5061004872c1a3d23b1238cc50387572L562-R576) [[5]](diffhunk://#diff-e8b7a658e21d8cfe8751ded76ca6956d5061004872c1a3d23b1238cc50387572L667-R683) [[6]](diffhunk://#diff-e8b7a658e21d8cfe8751ded76ca6956d5061004872c1a3d23b1238cc50387572L780-R796) [[7]](diffhunk://#diff-e8b7a658e21d8cfe8751ded76ca6956d5061004872c1a3d23b1238cc50387572L1017-R1033) [[8]](diffhunk://#diff-cb5048567bbfa27afeda8641244f1ed0e61453d773861c897e322678ac666264L437-R443) [[9]](diffhunk://#diff-cb5048567bbfa27afeda8641244f1ed0e61453d773861c897e322678ac666264R454) [[10]](diffhunk://#diff-07771d9c5572901395d5fe7cd5ea4f3e7a11634517ad5000d4e7ec54f9833edcR18-R32)

**Codebase improvements and consistency:**

* Refactored variable declarations in `Notifications.py` for clarity and type safety, and improved request body construction and error handling in notification sending logic. [[1]](diffhunk://#diff-675938cb2bd2cad7b4782c9c024db9492a126e77a3691bf6fa5d5f0ce0f67ad0L147-R154) [[2]](diffhunk://#diff-675938cb2bd2cad7b4782c9c024db9492a126e77a3691bf6fa5d5f0ce0f67ad0L409-R457) [[3]](diffhunk://#diff-675938cb2bd2cad7b4782c9c024db9492a126e77a3691bf6fa5d5f0ce0f67ad0L426-R474) [[4]](diffhunk://#diff-675938cb2bd2cad7b4782c9c024db9492a126e77a3691bf6fa5d5f0ce0f67ad0L440-R494) [[5]](diffhunk://#diff-675938cb2bd2cad7b4782c9c024db9492a126e77a3691bf6fa5d5f0ce0f67ad0L452-R504) [[6]](diffhunk://#diff-675938cb2bd2cad7b4782c9c024db9492a126e77a3691bf6fa5d5f0ce0f67ad0L215-R218) [[7]](diffhunk://#diff-675938cb2bd2cad7b4782c9c024db9492a126e77a3691bf6fa5d5f0ce0f67ad0L320-R325)

**UI improvements:**

* Enhanced the notification form in `NotificationForm.vue` by making help text bold and clarifying instructions for several fields. [[1]](diffhunk://#diff-13d051cca754cccd4579079ab2775bf4993345dc5cecdeeaadadd7d1794b8e1cL51-R51) [[2]](diffhunk://#diff-13d051cca754cccd4579079ab2775bf4993345dc5cecdeeaadadd7d1794b8e1cL66-R66) [[3]](diffhunk://#diff-13d051cca754cccd4579079ab2775bf4993345dc5cecdeeaadadd7d1794b8e1cL84-R90) [[4]](diffhunk://#diff-13d051cca754cccd4579079ab2775bf4993345dc5cecdeeaadadd7d1794b8e1cL108-R110)