### PR TITLE
[FIX] Chromium browser does not render subtitles after HLS attach

### DIFF
--- a/app/library/Playlist.py
+++ b/app/library/Playlist.py
@@ -42,6 +42,6 @@ class Playlist:
             )
 
         playlist.append(f"#EXT-X-STREAM-INF:PROGRAM-ID=1{subs}")
-        playlist.append(f"{self.url}api/player/m3u8/video/{quote(ref)}.m3u8")
+        playlist.append(f"{self.url}api/player/m3u8/video/{quote(str(ref))}.m3u8")
 
         return "\n".join(playlist)

--- a/ui/app/utils/index.ts
+++ b/ui/app/utils/index.ts
@@ -456,9 +456,10 @@ const getQueryParams = (url: string = window.location.search): Record<string, st
  * @param config - The application config object.
  * @param item - The item containing filename/folder.
  * @param base - The base endpoint type (default: 'api/download').
+ * @param playlist - Whether to generate a playlist URL (default: false).
  * @returns The fully constructed download URI.
  */
-const makeDownload = (config: any, item: StoreItem | { folder?: string; filename: string }, base: string = 'api/download'): string => {
+const makeDownload = (config: any, item: StoreItem | { folder?: string; filename: string }, base: string = 'api/download', playlist: boolean = false): string => {
   let baseDir = 'api/player/m3u8/video/'
   if ('m3u8' !== base) {
     baseDir = `${base}/`
@@ -474,7 +475,7 @@ const makeDownload = (config: any, item: StoreItem | { folder?: string; filename
   }
 
   const url = `/${sTrim(baseDir, '/')}${encodePath(item.filename)}`
-  return uri('m3u8' === base ? `${url}.m3u8` : url)
+  return uri('m3u8' === base || true === playlist ? `${url}.m3u8` : url)
 }
 
 /**


### PR DESCRIPTION
* Added a new `restoreDefaultTextTrack` function in `VideoPlayer.vue` to ensure that the subtitles are restored during/after source change.
* Fixed a potential bug in `Playlist.py` by ensuring that `ref` is always converted to a string before URL quoting, preventing errors when non-string types are passed.