### PR TITLE
Fix: tasks were shown as disabled even if they are actually enabled.

### DIFF
--- a/ui/app/pages/tasks.vue
+++ b/ui/app/pages/tasks.vue
@@ -262,7 +262,7 @@
                 <span class="icon" v-if="item.in_progress">
                   <i class="fa-solid fa-spinner fa-spin has-text-info" />
                 </span>
-                <span class="tag is-danger is-small ml-1" v-if="!task.enabled">Disabled</span>
+                <span class="tag is-danger is-small ml-1" v-if="!item.enabled">Disabled</span>
               </div>
               <div class="card-header-icon">
                 <div class="field is-grouped">


### PR DESCRIPTION
This pull request makes a minor fix in the `ui/app/pages/tasks.vue` file to ensure the "Disabled" tag is displayed correctly for each task item.

* Bug fix:
  * Corrected the condition for showing the "Disabled" tag by checking `item.enabled` instead of `task.enabled`.