### PR TITLE
Fix: prevent sending only space as download path

### DIFF
--- a/ui/app/components/NewDownload.vue
+++ b/ui/app/components/NewDownload.vue
@@ -9,7 +9,7 @@
                 <span class="icon"><i class="fa-solid fa-link" /></span>
                 <span class="has-tooltip" v-tooltip="'Use Shift+Enter to switch to multiline input mode.'">
                   URLs separated by newlines or <span class="is-bold is-lowercase">{{ getSeparatorsName(separator)
-                    }}</span>
+                  }}</span>
                 </span>
               </label>
               <div class="field is-grouped">
@@ -401,6 +401,16 @@ const splitUrls = (urlString: string): Array<string> => {
 }
 
 const addDownload = async () => {
+  if (' ' === form.value?.folder) {
+    toast.warning('The download folder contain only spaces. Resetting to default.')
+    form.value.folder = ''
+    await nextTick()
+  }
+
+  if (form.value.folder) {
+    form.value.folder = form.value.folder.trim()
+  }
+
   let form_cli = (form.value?.cli || '').trim()
 
   if (dlFields.value && Object.keys(dlFields.value).length > 0) {
@@ -568,6 +578,16 @@ onMounted(async () => {
     form.value.preset = config.app.default_preset
   }
 
+  if (' ' === form.value?.folder) {
+    toast.warning('The download folder contain only spaces. Resetting to default.')
+    form.value.folder = ''
+    await nextTick()
+  }
+
+  if (form.value.folder) {
+    form.value.folder = form.value.folder.trim()
+  }
+
   if (config.isLoaded() && form.value?.preset && !config.presets.some(p => p.name === form.value.preset)) {
     form.value.preset = config.app.default_preset
   }
@@ -678,6 +698,9 @@ const testDownloadOptions = async (): Promise<void> => {
   }
 
   let form_cli = (form.value?.cli || '').trim()
+  if (' ' === form.value?.folder) {
+    form.value.folder = ''
+  }
 
   if (dlFields.value && Object.keys(dlFields.value).length > 0) {
     const joined = []


### PR DESCRIPTION
In previous versions, a user my mistakenly set space as download folder, which overrides the preset download path causing confusion to user by downloading to base download path.

This fix will show a warning to user when the download path is set to only a space, and it will be reset before sending to backend. 

Ref #520 