### PR TITLE
Refactor: playlists sometimes return different ID what we got

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,8 @@
         "YTP_DOWNLOAD_PATH": "${workspaceFolder}/var/downloads",
         "YTP_TEMP_PATH": "${workspaceFolder}/var/tmp",
         "PYDEVD_DISABLE_FILE_VALIDATION": "1",
-        "YTP_IGNORE_UI": "true"
+        "YTP_IGNORE_UI": "true",
+        "YTP_DEBUG": "true"
       },
     },
     {

--- a/app/library/Download.py
+++ b/app/library/Download.py
@@ -296,8 +296,9 @@ class Download:
                         f"Live stream detected for '{self.info.title}', The following opts '{deletedOpts=}' have been deleted."
                     )
 
-            hasFormats: bool = len(self.info_dict.get("formats", [])) > 0 or self.info_dict.get("url")
-            if isinstance(self.info_dict, dict) and not hasFormats:
+            if isinstance(self.info_dict, dict) and not (
+                len(self.info_dict.get("formats", [])) > 0 or self.info_dict.get("url")
+            ):
                 msg: str = f"Failed to extract any formats for '{self.info.url}'."
                 if filtered_logs := extract_ytdlp_logs(self.logs):
                     msg += " " + ", ".join(filtered_logs)


### PR DESCRIPTION
* Add new logic to re-check the archive after extraction, accounting for cases where playlist or extractor returns a different ID than initially generated. 
* Updated file removal logic to ensure that local files are only deleted if the download is finished and a filename is present, preventing potential errors.
* Fix a bug that happens when auto start disabled, the format checking was happening on possibly null info_dict thus triggering error.