### PR TITLE
fix: sometimes downloads fails due to pickling issue

### DIFF
--- a/app/library/downloads/core.py
+++ b/app/library/downloads/core.py
@@ -393,7 +393,7 @@ class Download:
         """
         state: dict[str, Any] = self.__dict__.copy()
 
-        excluded_keys: tuple[str, ...] = ("_notify",)
+        excluded_keys: tuple[str, ...] = ("_notify", "_status_tracker")
         for key in excluded_keys:
             if key in state:
                 state[key] = None


### PR DESCRIPTION
Since our downloads refactor, some users are experiencing serialization issues related to event handler. 

I was not able to reproduce it locally however tracing possible paths we were able to identify a possible place where pickling was an issue. 

The fix was deployed and user confirm it was fixed.