### PR TITLE
fix: update import path for fetch_info in HandleTask class. Closes #561

### DIFF
--- a/app/features/tasks/definitions/results.py
+++ b/app/features/tasks/definitions/results.py
@@ -90,7 +90,7 @@ class HandleTask(TaskSchema):
             indicating if the operation was successful, and a message.
 
         """
-        from app.features.ytdlp.ytdlp import fetch_info
+        from app.features.ytdlp.extractor import fetch_info
 
         if not self.url:
             return ({}, False, "No URL found in task parameters.")
@@ -122,7 +122,7 @@ class HandleTask(TaskSchema):
             tuple[bool, str] | dict[str, Any]: Either an error tuple or a dict with 'file' and 'items' keys.
 
         """
-        from app.features.ytdlp.ytdlp import fetch_info
+        from app.features.ytdlp.extractor import fetch_info
 
         if not self.url:
             return (False, "No URL found in task parameters.")

--- a/app/tests/test_download.py
+++ b/app/tests/test_download.py
@@ -395,9 +395,7 @@ class TestDownloadSpawnPickling:
     def setup_method(self):
         EventBus._reset_singleton()
 
-    def test_spawn_pickling_ignores_local_event_listener(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
+    def test_spawn_pickling_ignores_local_event_listener(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         class Cfg:
             debug = False
             ytdlp_debug = False


### PR DESCRIPTION
This pull request primarily updates import statements in the `results.py` file to reference the correct module for fetching information, and includes a minor formatting change in a test file. The main focus is on correcting the import source for the `fetch_info` function.

**Imports and Dependency Management:**

* Changed the import of `fetch_info` in both `fetch_metadata` and `_mark_logic` methods from `app.features.ytdlp.ytdlp` to `app.features.ytdlp.extractor`, ensuring the correct module is used for fetching information. [[1]](diffhunk://#diff-d75f101ec6d61c619f5eb79163aa4e99e5e10b771861e90b41b08078a05c07abL93-R93) [[2]](diffhunk://#diff-d75f101ec6d61c619f5eb79163aa4e99e5e10b771861e90b41b08078a05c07abL125-R125)