### PR TITLE
fix: issue with spawn platforms

### DIFF
--- a/app/features/ytdlp/ytdlp_opts.py
+++ b/app/features/ytdlp/ytdlp_opts.py
@@ -129,10 +129,10 @@ class YTDLPCli:
             msg = f"Expected Item instance, got {type(item).__name__}"
             raise ValueError(msg)
 
+        self._config: Config = config or Config.get_instance()
         self.item = item
         preset_name = item.preset or self._config.default_preset
         self.preset: Preset | None = YTDLPCli._get_presets().get(preset_name)
-        self._config: Config = config or Config.get_instance()
 
     @staticmethod
     def _get_presets():

--- a/app/library/downloads/core.py
+++ b/app/library/downloads/core.py
@@ -25,6 +25,7 @@ from app.library.Utils import create_cookies_file
 from ...features.ytdlp.extractor import REEXTRACT_INFO_KEY, extract_info_sync
 from .hooks import HookHandlers, NestedLogger
 from .process_manager import ProcessManager
+from .runtime import ensure_download_runtime
 from .status_tracker import StatusTracker
 from .temp_manager import TempManager
 from .types import Terminator
@@ -117,6 +118,8 @@ class Download:
             raise RuntimeError(msg)
 
         try:
+            ensure_download_runtime(logger=self.logger)
+
             params = (
                 self.info.get_ytdlp_opts()
                 .add(

--- a/app/library/downloads/runtime.py
+++ b/app/library/downloads/runtime.py
@@ -1,0 +1,84 @@
+"""Runtime initialization for download worker processes."""
+
+from __future__ import annotations
+
+import asyncio
+import multiprocessing
+import os
+import threading
+from typing import TYPE_CHECKING
+
+from app.features.presets.repository import PresetsRepository
+from app.features.presets.service import Presets
+from app.library.config import Config
+from app.library.log import get_logger
+from app.library.sqlite_store import SqliteStore
+
+LOG = get_logger()
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+_BOOTSTRAP_STATE: dict[str, int | None] = {"pid": None}
+_LOCK = threading.Lock()
+
+
+def _start_method() -> str | None:
+    method = multiprocessing.get_start_method(allow_none=True)
+    if method:
+        return method
+
+    try:
+        return multiprocessing.get_context().get_start_method()
+    except RuntimeError:
+        return None
+
+
+def _should_bootstrap() -> bool:
+    if multiprocessing.current_process().name == "MainProcess":
+        return False
+
+    return _start_method() in {"spawn", "forkserver"}
+
+
+async def _bootstrap_download_runtime() -> None:
+    config = Config.get_instance()
+    await SqliteStore.get_instance(db_path=config.db_file).get_connection()
+
+    repo = PresetsRepository.get_instance()
+    await Presets.get_instance().refresh_cache(await repo.all())
+
+
+def _run_bootstrap() -> None:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        asyncio.run(_bootstrap_download_runtime())
+        return
+
+    msg = "Cannot initialize download worker runtime while an event loop is already running."
+    raise RuntimeError(msg)
+
+
+def ensure_download_runtime(logger: Logger | None = None) -> bool:
+    """Initialize process-local runtime state for spawned download workers."""
+    if not _should_bootstrap():
+        return False
+
+    pid = os.getpid()
+    if _BOOTSTRAP_STATE["pid"] == pid:
+        return False
+
+    with _LOCK:
+        if _BOOTSTRAP_STATE["pid"] == pid:
+            return False
+
+        log = logger or LOG
+        log.debug(
+            "Initializing download worker runtime for process PID=%s.",
+            pid,
+            extra={"process_id": pid, "start_method": _start_method()},
+        )
+        _run_bootstrap()
+        _BOOTSTRAP_STATE["pid"] = pid
+        return True

--- a/app/tests/test_download.py
+++ b/app/tests/test_download.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import signal
@@ -11,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, patch
 import pytest
 
 from app.library.Events import EventBus, Events
+import app.library.downloads.runtime as download_runtime
 from app.library.downloads import Download, NestedLogger, Terminator
 from app.library.downloads.hooks import HookHandlers
 from app.library.downloads.pool_manager import PoolManager
@@ -277,6 +279,97 @@ class TestDownloadStale:
 
 
 class TestDownloadFlow:
+    def test_download_bootstraps_before_options(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from app.features.presets.models import PresetModel
+        from app.features.presets.service import Presets
+
+        class Cfg:
+            debug = False
+            ytdlp_debug = False
+            max_workers = 1
+            temp_keep = False
+            temp_disabled = True
+            download_info_expires = 3600
+            download_path = "/downloads"
+            temp_path = "/tmp"
+            output_template = "%(title)s.%(ext)s"
+            output_template_chapter = "%(title)s.%(ext)s"
+            disable_exec = False
+
+            @staticmethod
+            def get_instance():
+                return Cfg
+
+            @staticmethod
+            def get_replacers():
+                return {
+                    "os_sep": os.path.sep,
+                    "download_path": Cfg.download_path,
+                    "temp_path": Cfg.temp_path,
+                    "config_path": "/config",
+                    "archive_file": "/config/archive.log",
+                }
+
+        Presets._reset_singleton()
+        monkeypatch.setattr("app.library.downloads.core.Config", Cfg)
+        monkeypatch.setattr("app.features.ytdlp.ytdlp_opts.Config", Cfg)
+
+        def bootstrap(*, logger=None):
+            del logger
+            preset = PresetModel(
+                id=1,
+                name="native",
+                description="",
+                folder="",
+                template="",
+                cookies="",
+                cli="--format worst",
+                default=False,
+                priority=0,
+            )
+            asyncio.run(Presets.get_instance().refresh_cache([preset]))
+            return True
+
+        monkeypatch.setattr("app.library.downloads.core.ensure_download_runtime", bootstrap)
+
+        item = make_item()
+        item.preset = "native"
+        download = Download(
+            info=item,
+            info_dict={
+                "id": "test-id",
+                "url": "http://u",
+                "formats": [{"format_id": "18"}],
+                "epoch": int(time.time()),
+            },
+        )
+        download.status_queue = cast(Any, DummyQueue())
+        download._hook_handlers = Mock(
+            progress_hook=Mock(),
+            postprocessor_hook=Mock(),
+            post_hook=Mock(),
+        )
+
+        captured: dict[str, Any] = {}
+
+        class FakeYTDLP:
+            def __init__(self, params):
+                captured["params"] = params
+                self._download_retcode = 0
+                self._interrupted = False
+
+            def process_ie_result(self, ie_result, download):
+                return ie_result, download
+
+        monkeypatch.setattr("app.library.downloads.core.YTDLP", FakeYTDLP)
+
+        try:
+            download._download()
+        finally:
+            Presets._reset_singleton()
+
+        assert captured["params"]["format"] == "worst"
+
     def test_download_pushes_download_skipped_flag(self, monkeypatch: pytest.MonkeyPatch) -> None:
         class Cfg:
             debug = False
@@ -753,6 +846,64 @@ class TestDownloadSpawnPickling:
         assert state.get("_status_tracker") is None, "StatusTracker should be excluded from pickled state"
 
         ForkingPickler.dumps(download._download)
+
+
+class TestDownloadRuntime:
+    def test_fork_skip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setitem(download_runtime._BOOTSTRAP_STATE, "pid", None)
+        monkeypatch.setattr(
+            download_runtime.multiprocessing,
+            "current_process",
+            lambda: SimpleNamespace(name="download-test"),
+        )
+        monkeypatch.setattr(download_runtime.multiprocessing, "get_start_method", lambda allow_none=True: "fork")
+        run = Mock()
+        monkeypatch.setattr(download_runtime, "_run_bootstrap", run)
+
+        assert download_runtime.ensure_download_runtime() is False
+        run.assert_not_called()
+
+    def test_spawn_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setitem(download_runtime._BOOTSTRAP_STATE, "pid", None)
+        monkeypatch.setattr(
+            download_runtime.multiprocessing,
+            "current_process",
+            lambda: SimpleNamespace(name="download-test"),
+        )
+        monkeypatch.setattr(download_runtime.multiprocessing, "get_start_method", lambda allow_none=True: "spawn")
+        monkeypatch.setattr(download_runtime.os, "getpid", lambda: 123)
+        run = Mock()
+        monkeypatch.setattr(download_runtime, "_run_bootstrap", run)
+
+        assert download_runtime.ensure_download_runtime() is True
+        assert download_runtime.ensure_download_runtime() is False
+        run.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_bootstrap_loads_presets(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        config = SimpleNamespace(db_file="/tmp/test.db")
+        store = SimpleNamespace(get_connection=AsyncMock())
+        repo = SimpleNamespace(all=AsyncMock(return_value=["preset"]))
+        presets = SimpleNamespace(refresh_cache=AsyncMock())
+
+        monkeypatch.setattr(download_runtime, "Config", SimpleNamespace(get_instance=lambda: config))
+        monkeypatch.setattr(
+            download_runtime,
+            "SqliteStore",
+            SimpleNamespace(get_instance=lambda db_path=None: store),
+        )
+        monkeypatch.setattr(
+            download_runtime,
+            "PresetsRepository",
+            SimpleNamespace(get_instance=lambda: repo),
+        )
+        monkeypatch.setattr(download_runtime, "Presets", SimpleNamespace(get_instance=lambda: presets))
+
+        await download_runtime._bootstrap_download_runtime()
+
+        store.get_connection.assert_awaited_once_with()
+        repo.all.assert_awaited_once_with()
+        presets.refresh_cache.assert_awaited_once_with(["preset"])
 
 
 class TestTempManager:

--- a/ui/app/pages/logs.vue
+++ b/ui/app/pages/logs.vue
@@ -77,6 +77,18 @@
           Wrap
         </UButton>
 
+        <UDropdownMenu :items="copyMenuItems" :content="copyMenuContent" :modal="false">
+          <UButton
+            color="neutral"
+            variant="outline"
+            size="sm"
+            icon="i-lucide-copy"
+            trailing-icon="i-lucide-chevron-down"
+          >
+            Copy
+          </UButton>
+        </UDropdownMenu>
+
         <USelectMenu
           v-model="selectedLevels"
           :items="levelFilterItems"
@@ -175,13 +187,14 @@
                   </UTooltip>
                   <UButton
                     color="neutral"
-                    variant="ghost"
+                    variant="soft"
                     size="xs"
                     icon="i-lucide-panel-right-open"
-                    aria-label="Open log details"
-                    class="inline-flex align-[-0.2em] opacity-70 hover:opacity-100"
+                    class="inline-flex align-[-0.2em]"
                     @click="openLogDetails(entry.log)"
-                  />
+                  >
+                    Details
+                  </UButton>
                   <span
                     :class="logLevelBadgeClass(getLogLevel(entry.log.level))"
                     @click="openLogDetails(entry.log)"
@@ -256,7 +269,7 @@ import type { EventSourceMessage } from '@microsoft/fetch-event-source';
 import moment from 'moment';
 import { useStorage } from '@vueuse/core';
 import type { log_line } from '~/types/logs';
-import { parse_api_error, request, uri } from '~/utils';
+import { copyText, parse_api_error, request, uri } from '~/utils';
 import { requirePageShell } from '~/utils/topLevelNavigation';
 
 type FilteredLogEntry = {
@@ -345,6 +358,21 @@ const hasActiveFilter = computed(() => hasTextFilter.value);
 const canLoadFilteredHistory = computed(
   () => hasTextFilter.value && !reachedEnd.value && logs.value.length > 0,
 );
+const copyMenuContent = computed(() => ({ align: 'end' as const }));
+const copyMenuItems = computed(() => [
+  [
+    {
+      label: 'Copy Rendered Logs',
+      icon: 'i-lucide-file-text',
+      onSelect: () => copyText(copyRenderedLogText.value),
+    },
+    {
+      label: 'Copy Raw Logs',
+      icon: 'i-lucide-file-code',
+      onSelect: () => copyText(copyRawLogText.value),
+    },
+  ],
+]);
 const levelCounts = computed<Record<LogLevel, number>>(() => {
   const counts: Record<LogLevel, number> = {
     debug: 0,
@@ -729,6 +757,31 @@ const exceptionSummary = (log: log_line): string => {
 
   return type || message;
 };
+
+const formatLogLine = (log: log_line): string =>
+  [
+    log.datetime,
+    getLogLevel(log.level).toUpperCase(),
+    log.logger ? `[${log.logger}]` : '',
+    exceptionSummary(log) ? `${log.message}: ${exceptionSummary(log)}` : log.message,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+const rawLogText = computed(() => logs.value.map((log) => JSON.stringify(log)).join('\n'));
+const renderedLogText = computed(() => logs.value.map((log) => formatLogLine(log)).join('\n'));
+const filteredRawLogText = computed(() =>
+  filteredLogs.value.map((entry) => JSON.stringify(entry.log)).join('\n'),
+);
+const filteredRenderedLogText = computed(() =>
+  filteredLogs.value.map((entry) => formatLogLine(entry.log)).join('\n'),
+);
+const copyRawLogText = computed(() =>
+  hasActiveFilter.value ? filteredRawLogText.value : rawLogText.value,
+);
+const copyRenderedLogText = computed(() =>
+  hasActiveFilter.value ? filteredRenderedLogText.value : renderedLogText.value,
+);
 
 const searchableLog = (log: log_line): string =>
   [


### PR DESCRIPTION
This pull request introduces a new runtime initialization mechanism for download worker processes, improves test coverage for the download runtime bootstrap logic, and enhances the log viewer UI with new copy features and usability improvements. The most important changes are grouped below by backend and frontend themes.

**Backend: Download Worker Runtime Initialization**

* Added a new module `downloads.runtime` that ensures process-local runtime state is initialized for spawned download workers, including database connections and preset cache loading. This prevents issues with multiprocessing and ensures correct environment setup for each worker.
* Integrated the new `ensure_download_runtime` function into the download flow, so runtime initialization occurs before options are fetched for downloads.
* Added tests  to verify correct behavior of the runtime bootstrap logic, including process type detection, idempotency, and async preset loading.
* Minor refactor in `app/features/ytdlp/ytdlp_opts.py` to ensure the config instance is initialized before accessing preset information.

**Frontend: Log Viewer UI Enhancements**

* Added a "Copy" dropdown button to the logs page that allows users to copy either rendered or raw logs, with support for filtered or unfiltered views. 
* Improved the log entry details button by making it more visually prominent and changing its style for better accessibility.