### PR TITLE
fix: scope FlareSolverr cookies to target host and handle solve failures

### DIFF
--- a/app/library/cf_solver_shared.py
+++ b/app/library/cf_solver_shared.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import time
+import urllib.error
 import urllib.request
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
@@ -15,6 +16,35 @@ if TYPE_CHECKING:
 
 CACHE: Cache = Cache()
 LOG = get_logger()
+
+
+def _host_matches_cookie_domain(host: str, cookie_domain: str | None) -> bool:
+    """
+    Determine whether a cookie belongs to the given request host.
+
+    FlareSolverr hands every cookie we send to a real Chrome instance navigating to the target
+    URL. Chrome rejects cookies whose domain does not match the page being loaded with an
+    ``invalid cookie domain`` error, which aborts the whole solve with an HTTP 500. So we only
+    forward cookies whose domain matches the target host.
+
+    Args:
+        host (str): The hostname of the target URL.
+        cookie_domain (str | None): The cookie's domain attribute.
+
+    Returns:
+        bool: True if the cookie applies to the host, False otherwise.
+
+    """
+    host = (host or "").lower().strip(".")
+    domain = (cookie_domain or "").lower().strip(".")
+    if not host:
+        return False
+
+    # Host-only cookie (no domain) applies to the target by default.
+    if not domain:
+        return True
+
+    return host == domain or host.endswith(f".{domain}")
 
 
 def solver(url: str, cookies: list[dict[str, Any]], user_agent: str | None) -> dict[str, Any] | None:
@@ -54,7 +84,19 @@ def solver(url: str, cookies: list[dict[str, Any]], user_agent: str | None) -> d
     }
 
     if cookies:
-        payload["cookies"] = cookies
+        # Only forward cookies that belong to the target host. Sending a cookie for an unrelated
+        # domain makes FlareSolverr's Chrome reject it and fail the whole solve with an HTTP 500.
+        scoped_cookies = [c for c in cookies if _host_matches_cookie_domain(host, c.get("domain"))]
+        dropped: int = len(cookies) - len(scoped_cookies)
+        if dropped:
+            LOG.debug(
+                "Dropped %d cookie(s) not matching host '%s' before calling FlareSolverr.",
+                dropped,
+                host,
+                extra={"host": host, "dropped": dropped},
+            )
+        if scoped_cookies:
+            payload["cookies"] = scoped_cookies
 
     if user_agent:
         payload.setdefault("headers", {})["User-Agent"] = user_agent
@@ -70,8 +112,35 @@ def solver(url: str, cookies: list[dict[str, Any]], user_agent: str | None) -> d
         "Solving Cloudflare challenge for '%s' via FlareSolverr.", host, extra={"host": host, "endpoint": endpoint}
     )
     start_time = time.time()
-    with urllib.request.urlopen(req, timeout=float(config.flaresolverr_client_timeout)) as resp:  # noqa: S310
-        result = json.loads(resp.read().decode("utf-8"))
+    try:
+        with urllib.request.urlopen(req, timeout=float(config.flaresolverr_client_timeout)) as resp:  # noqa: S310
+            result = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        # FlareSolverr signals solve failures with an HTTP 500 and a JSON body describing why.
+        # urlopen raises before we can read that body, so pull the message out of the error here
+        # and degrade gracefully instead of letting the exception abort the whole extraction.
+        message: str | None = None
+        try:
+            message = json.loads(e.read().decode("utf-8")).get("message")
+        except Exception:
+            message = None
+
+        LOG.error(
+            "FlareSolverr returned HTTP %s while solving challenge for '%s': %s",
+            e.code,
+            host,
+            message or e.reason,
+            extra={"host": host, "endpoint": endpoint, "status_code": e.code, "solver_message": message},
+        )
+        return None
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        LOG.error(
+            "Failed to reach FlareSolverr for '%s': %s",
+            host,
+            e,
+            extra={"host": host, "endpoint": endpoint, "error": str(e)},
+        )
+        return None
 
     if "ok" != result.get("status"):
         LOG.error(

--- a/app/tests/test_cf_solver_shared.py
+++ b/app/tests/test_cf_solver_shared.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from unittest.mock import Mock, patch
+
+import pytest
+
+from app.library.cf_solver_shared import _host_matches_cookie_domain, solver
+
+
+class TestHostMatchesCookieDomain:
+    """Test the _host_matches_cookie_domain helper."""
+
+    @pytest.mark.parametrize(
+        ("host", "domain", "expected"),
+        [
+            ("www.pexels.com", ".pexels.com", True),
+            ("www.pexels.com", "pexels.com", True),
+            ("pexels.com", ".pexels.com", True),
+            ("www.pexels.com", ".vimeo.com", False),
+            ("www.pexels.com", "vimeo.com", False),
+            ("www.pexels.com", "", True),
+            ("www.pexels.com", None, True),
+            ("www.pexels.com", "notpexels.com", False),
+            ("", ".pexels.com", False),
+        ],
+    )
+    def test_matches(self, host, domain, expected):
+        assert _host_matches_cookie_domain(host, domain) is expected
+
+
+def _make_config():
+    config = Mock()
+    config.flaresolverr_url = "http://flaresolverr:8191/v1"
+    config.flaresolverr_max_timeout = 120
+    config.flaresolverr_client_timeout = 120
+    config.flaresolverr_cache_ttl = 600
+    return config
+
+
+class TestSolver:
+    """Test the solver() FlareSolverr entry point."""
+
+    @patch("app.library.cf_solver_shared.CACHE")
+    @patch("app.library.cf_solver_shared.urllib.request.urlopen")
+    @patch("app.library.config.Config")
+    def test_filters_cross_domain_cookies(self, mock_config_cls, mock_urlopen, mock_cache):
+        """Cookies for unrelated domains must not be forwarded to FlareSolverr."""
+        mock_config_cls.get_instance.return_value = _make_config()
+        mock_cache.get.return_value = None
+
+        resp = io.BytesIO(json.dumps({"status": "ok", "solution": {"cookies": [], "userAgent": "UA"}}).encode())
+        resp.__enter__ = lambda self=resp: self
+        resp.__exit__ = lambda *a: False
+        mock_urlopen.return_value = resp
+
+        cookies = [
+            {"name": "cf_bm_pexels", "value": "a", "domain": ".pexels.com", "path": "/"},
+            {"name": "vuid", "value": "b", "domain": ".vimeo.com", "path": "/"},
+            {"name": "g_state", "value": "c", "domain": "vimeo.com", "path": "/"},
+        ]
+
+        solver("https://www.pexels.com/video/x-123/", cookies, "UA")
+
+        sent = json.loads(mock_urlopen.call_args[0][0].data.decode())
+        forwarded_names = {c["name"] for c in sent.get("cookies", [])}
+        assert forwarded_names == {"cf_bm_pexels"}
+
+    @patch("app.library.cf_solver_shared.CACHE")
+    @patch("app.library.cf_solver_shared.urllib.request.urlopen")
+    @patch("app.library.config.Config")
+    def test_http_500_returns_none(self, mock_config_cls, mock_urlopen, mock_cache):
+        """A FlareSolverr HTTP 500 must degrade to None, not raise."""
+        mock_config_cls.get_instance.return_value = _make_config()
+        mock_cache.get.return_value = None
+
+        body = json.dumps({"status": "error", "message": "Error solving the challenge."}).encode()
+        mock_urlopen.side_effect = urllib.error.HTTPError(
+            url="http://flaresolverr:8191/v1",
+            code=500,
+            msg="Internal Server Error",
+            hdrs=None,
+            fp=io.BytesIO(body),
+        )
+
+        result = solver("https://www.pexels.com/video/x-123/", [], "UA")
+        assert result is None
+        mock_cache.set.assert_not_called()
+
+    @patch("app.library.cf_solver_shared.CACHE")
+    @patch("app.library.cf_solver_shared.urllib.request.urlopen")
+    @patch("app.library.config.Config")
+    def test_connection_error_returns_none(self, mock_config_cls, mock_urlopen, mock_cache):
+        """A transport error reaching FlareSolverr must degrade to None, not raise."""
+        mock_config_cls.get_instance.return_value = _make_config()
+        mock_cache.get.return_value = None
+        mock_urlopen.side_effect = urllib.error.URLError("connection refused")
+
+        result = solver("https://www.pexels.com/video/x-123/", [], "UA")
+        assert result is None


### PR DESCRIPTION
## Problem

When FlareSolverr is configured (`YTP_FLARESOLVERR_URL`), a solve can fail with a confusing error that looks like a bug in ytptube or yt-dlp:

```
ERROR: [CFSolver] Unexpected error: HTTPError: HTTP Error 500: Internal Server Error;
please report this issue on https://github.com/yt-dlp/yt-dlp/issues ...
```

The FlareSolverr container log reveals the real cause:

```
ERROR  Error: Error solving the challenge. Message: invalid cookie domain: Cookie 'domain' mismatch
INFO   POST http://flaresolverr:8191/v1 500 Internal Server Error
```

When solving a challenge for e.g. `pexels.com`, `cf_solver()` forwards the **entire** cookiejar — including cookies for unrelated domains such as `.vimeo.com` loaded from a shared `cookies.txt`. FlareSolverr feeds every cookie to a real Chrome instance navigating to the target URL, and Chrome rejects a `.vimeo.com` cookie on a `pexels.com` page with `invalid cookie domain`, aborting the whole solve with HTTP 500.

That 500 then compounds a second bug: `solver()` calls `urllib.request.urlopen()` with no error handling. FlareSolverr reports solve failures as HTTP 500 with a JSON body (`{"status":"error","message":...}`), but `urlopen` raises `HTTPError` before the existing `status != "ok"` check can read it, so the exception escapes and crashes the whole extraction instead of degrading gracefully.

## Fix

1. **Scope cookies to the target host** — only forward cookies whose domain matches the request host (`_host_matches_cookie_domain`). Mismatched-domain cookies are dropped before the FlareSolverr call.
2. **Handle FlareSolverr HTTP/transport errors** — catch `HTTPError` (reading the reported message from the body for the log), `URLError`, `TimeoutError`, and `OSError`, log a clear reason, and return `None` so yt-dlp falls back to the original Cloudflare error instead of the misleading "report to yt-dlp" crash.

## Tests

Adds `app/tests/test_cf_solver_shared.py` covering the domain-match helper, cross-domain cookie filtering (using the exact pexels/vimeo case from the report), the HTTP 500 path, and the connection-error path. Existing `cf_solver_handler` tests still pass (25 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)