### PR TITLE
refactor: use in form ualert for submission errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Example of the regular view interface.
 Example of the Simple mode interface.
 ![Short screenshot](https://raw.githubusercontent.com/ArabCoders/ytptube/dev/sc_simple.jpg)
 
+The YTPTube frontend is available in English, العربية, Français, 中文, and 日本語. See the [language FAQ](FAQ.md#how-do-i-change-the-ui-language).
+
 # YTPTube Features.
 
 * Multi-download support.
@@ -39,7 +41,6 @@ Example of the Simple mode interface.
 * Custom browser extensions, bookmarklets and iOS shortcuts to send links to YTPTube instance.
 * A bundled executable version for Windows, macOS and Linux. `MacOS version is untested`.
 * Use playwright or selenium for extractors that require a browser. see [related FAQ](FAQ.md#how-to-use-the-browser-extractor).
-* Multi-language UI. See [language FAQ](FAQ.md#how-do-i-change-the-ui-language).
 
 Please read the [FAQ](FAQ.md) for more information.
 

--- a/ui/app/components/FormSubmitError.vue
+++ b/ui/app/components/FormSubmitError.vue
@@ -1,0 +1,37 @@
+<template>
+  <UAlert
+    v-if="message && !dismissed"
+    color="error"
+    variant="solid"
+    icon="i-lucide-circle-alert"
+    role="button"
+    tabindex="0"
+    class="sticky top-0 z-20 mb-4 cursor-pointer bg-error/90 shadow-md backdrop-blur-sm"
+    @click="dismiss"
+    @keydown.enter="dismiss"
+    @keydown.space.prevent="dismiss"
+  >
+    <template #description>
+      <p class="whitespace-pre-line text-inverted">{{ message }}</p>
+    </template>
+  </UAlert>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  message?: string | null;
+}>();
+
+const dismissed = ref(false);
+
+const dismiss = (): void => {
+  dismissed.value = true;
+};
+
+watch(
+  () => props.message,
+  () => {
+    dismissed.value = false;
+  },
+);
+</script>

--- a/ui/app/components/NewDownload.vue
+++ b/ui/app/components/NewDownload.vue
@@ -1,5 +1,6 @@
 <template>
   <main class="space-y-4">
+    <FormSubmitError :message="submitError" />
     <form autocomplete="off" class="space-y-4" @submit.prevent="addDownload">
       <div class="ytp-card p-4 sm:p-6 space-y-4">
         <div class="space-y-4">
@@ -399,7 +400,7 @@
                 :rows="5"
                 :placeholder="getDefault('cookies', t('common.cookiesPlaceholder'))"
                 class="w-full"
-                @error="(msg: string) => toast.error(msg)"
+                @error="(message: string) => (submitError = message)"
               />
             </UFormField>
           </div>
@@ -594,6 +595,7 @@ const storedCommand = useStorage<string>('console_command', '');
 const testResultsClasses = useStorage<string>('modal_text_classes', '');
 
 const addInProgress = ref<boolean>(false);
+const submitError = ref('');
 const showOptions = ref<boolean>(false);
 const showTestResults = ref<boolean>(false);
 const showPlaylistPicker = ref<boolean>(false);
@@ -909,6 +911,7 @@ const splitUrls = (urlString: string): Array<string> => {
 };
 
 const addDownload = async () => {
+  submitError.value = '';
   if (form.value.folder) {
     form.value.folder = form.value.folder.trim();
   }
@@ -975,11 +978,12 @@ const addDownload = async () => {
 
     const data = await response.json();
     if (!response.ok) {
-      toast.error((await parse_api_error(data)) || t('queue.failedToAdd'));
+      submitError.value = (await parse_api_error(data)) || t('queue.failedToAdd');
       return;
     }
 
     let had_errors = false;
+    const errors: string[] = [];
 
     if (200 === response.status) {
       data.forEach((item: Record<string, any>) => {
@@ -993,9 +997,12 @@ const addDownload = async () => {
           return;
         }
 
-        toast.error(t('common.errorPrefix', { msg: item.msg || t('queue.failedToAdd') }));
+        const message = t('common.errorPrefix', { msg: item.msg || t('queue.failedToAdd') });
+        errors.push(message);
       });
     }
+
+    submitError.value = errors.join('\n');
 
     if (202 === response.status) {
       toast.success(data.message, { timeout: 2000 });
@@ -1005,9 +1012,10 @@ const addDownload = async () => {
       form.value.url = '';
       emitter('clear_form');
     }
-  } catch (e: any) {
-    console.error(e);
-    toast.error(t('common.errorPrefix', { msg: e.message }));
+  } catch (error) {
+    console.error(error);
+    const message = error instanceof Error ? error.message : t('queue.failedToAdd');
+    submitError.value = t('common.errorPrefix', { msg: message });
   } finally {
     addInProgress.value = false;
   }
@@ -1050,8 +1058,8 @@ const convertOptions = async (args: string) => {
     }
 
     return response.opts;
-  } catch (e: any) {
-    toast.error(e.message);
+  } catch (error) {
+    submitError.value = error instanceof Error ? error.message : t('common.unknownError');
   }
 
   return null;

--- a/ui/app/components/PlaylistPicker.vue
+++ b/ui/app/components/PlaylistPicker.vue
@@ -71,17 +71,7 @@
           <UIcon name="i-lucide-loader-circle" class="size-10 animate-spin text-toned" />
         </div>
 
-        <UAlert
-          v-else-if="errorMessage"
-          color="error"
-          variant="soft"
-          icon="i-lucide-circle-alert"
-          :title="t('common.unableToLoadInfo')"
-        >
-          <template #description>
-            <p class="whitespace-pre-line wrap-break-word">{{ errorMessage }}</p>
-          </template>
-        </UAlert>
+        <FormSubmitError v-else-if="errorMessage" :message="errorMessage" />
 
         <UEmpty
           v-else-if="filteredEntries.length === 0"
@@ -238,7 +228,6 @@ const emitter = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const toast = useNotification();
 const query = ref('');
 const entries = ref<PlaylistEntry[]>([]);
 const entryScrollEl = ref<HTMLElement | null>(null);
@@ -524,7 +513,6 @@ const loadEntries = async (): Promise<void> => {
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : t('common.failedFetch');
     errorMessage.value = message;
-    toast.error(t('common.errorPrefix', { msg: message }));
   } finally {
     isLoading.value = false;
   }

--- a/ui/app/components/PresetForm.vue
+++ b/ui/app/components/PresetForm.vue
@@ -1,5 +1,6 @@
 <template>
   <form id="presetForm" autocomplete="off" class="space-y-6" @submit.prevent="checkInfo">
+    <FormSubmitError :message="action.message.value" />
     <UAlert
       v-if="formError && hasFormContent"
       color="warning"
@@ -261,7 +262,7 @@
             v-model="form.cookies"
             :disabled="addInProgress"
             dir="ltr"
-            @error="(msg: string) => toast.error(msg)"
+            @error="showActionError"
             :placeholder="t('common.cookiesPlaceholder')"
           />
         </UFormField>
@@ -336,9 +337,9 @@ const props = defineProps<{
 }>();
 
 const config = useYtpConfig();
-const toast = useNotification();
 const dialog = useDialog();
 const { presets, findPreset, selectItems } = usePresetOptions();
+const action = useFormSubmit();
 
 const form = reactive<Preset>({
   name: '',
@@ -412,6 +413,7 @@ watch(
 
     importString.value = '';
     selectedPreset.value = '';
+    action.clear();
     nextTick(() => {
       markClean();
       emitter('dirty-change', false);
@@ -437,6 +439,10 @@ watch(
 
 const triggerCookieUpload = (): void => {
   cookiesDropzoneRef.value?.triggerFileSelect();
+};
+
+const showActionError = (message: string): void => {
+  action.setError(new Error(message));
 };
 
 const hasFormContent = computed(() => {
@@ -493,6 +499,7 @@ const confirmImportOverwrite = async (): Promise<boolean> => {
 };
 
 const convertOptions = async (args: string): Promise<Record<string, any> | null> => {
+  action.clear();
   try {
     const response = await convertCliOptions(args);
 
@@ -505,13 +512,14 @@ const convertOptions = async (args: string): Promise<Record<string, any> | null>
     }
 
     return response.opts as Record<string, any>;
-  } catch (error: any) {
-    toast.error(error.message);
+  } catch (error) {
+    showActionError(error instanceof Error ? error.message : t('common.unknownError'));
     return null;
   }
 };
 
 const checkInfo = async (): Promise<void> => {
+  action.clear();
   if (formError.value) {
     return;
   }
@@ -544,9 +552,10 @@ const checkInfo = async (): Promise<void> => {
 };
 
 const importItem = async (): Promise<void> => {
+  action.clear();
   const value = importString.value.trim();
   if (!value) {
-    toast.error(t('common.validationImportRequired'));
+    showActionError(t('common.validationImportRequired'));
     return;
   }
 
@@ -558,8 +567,11 @@ const importItem = async (): Promise<void> => {
     const item = decode(value) as Preset & ImportedItem;
 
     if (!item?._type || 'preset' !== item._type) {
-      toast.error(
-        t('common.validationInvalidImport', { expected: 'preset', type: item._type ?? 'unknown' }),
+      showActionError(
+        t('common.validationInvalidImport', {
+          expected: 'preset',
+          type: item?._type ?? 'unknown',
+        }),
       );
       return;
     }
@@ -585,13 +597,19 @@ const importItem = async (): Promise<void> => {
 
     importString.value = '';
     showImport.value = false;
-  } catch (error: any) {
+    action.clear();
+  } catch (error) {
     console.error(error);
-    toast.error(t('common.validationImportParseFailed', { error: error.message }));
+    showActionError(
+      t('common.validationImportParseFailed', {
+        error: error instanceof Error ? error.message : t('common.unknownError'),
+      }),
+    );
   }
 };
 
 const importExistingPreset = async (): Promise<void> => {
+  action.clear();
   if (!selectedPreset.value) {
     return;
   }
@@ -603,7 +621,7 @@ const importExistingPreset = async (): Promise<void> => {
 
   const preset = findPreset(selectedPreset.value);
   if (!preset) {
-    toast.error(t('common.presetNotFoundShort'));
+    showActionError(t('common.presetNotFoundShort'));
     return;
   }
 
@@ -616,6 +634,7 @@ const importExistingPreset = async (): Promise<void> => {
 
   await nextTick();
   selectedPreset.value = '';
+  action.clear();
 };
 
 onMounted(() => {

--- a/ui/app/components/TaskForm.vue
+++ b/ui/app/components/TaskForm.vue
@@ -1,11 +1,11 @@
 <template>
   <form id="taskForm" autocomplete="off" class="space-y-4" @submit.prevent="checkInfo">
     <UAlert
-      v-if="formError && hasFormContent"
+      v-if="displayError && hasFormContent"
       color="warning"
       variant="soft"
       icon="i-lucide-triangle-alert"
-      :title="formError"
+      :title="displayError"
       class="sticky top-0 z-10 shadow-sm"
     />
 
@@ -209,7 +209,7 @@
 
       <div class="space-y-5">
         <div class="grid gap-4 xl:grid-cols-2">
-          <UFormField class="w-full" :ui="fieldUi">
+          <UFormField class="w-full" :ui="fieldUi" :error="timerError || undefined">
             <template #label>
               <div class="flex flex-wrap items-center gap-2">
                 <UIcon name="i-lucide-clock-3" class="size-4 text-toned" />
@@ -513,6 +513,7 @@ const CHANNEL_REGEX =
 const GENERIC_RSS_REGEX = /\.(rss|atom)(\?.*)?$|handler=rss/i;
 
 const form = reactive<Task>(createDefaultTask(props.task));
+const timerError = ref('');
 
 const dirtySource = computed(() => ({
   reference: props.reference ?? null,
@@ -528,6 +529,7 @@ const fieldUi = {
   container: 'space-y-2',
   description: 'text-sm text-toned',
   hint: 'text-sm text-toned',
+  error: 'text-sm text-error',
 };
 
 const editorFieldUi = {
@@ -718,7 +720,11 @@ const formError = computed(() => {
 
   return '';
 });
-watch(formError, (value) => emitter('valid-change', !value), { immediate: true });
+const displayError = computed(() => formError.value || timerError.value);
+watch(displayError, (value) => emitter('valid-change', !value), { immediate: true });
+watch([() => form.url, () => form.preset, () => form.timer, () => form.handler_enabled], () => {
+  timerError.value = '';
+});
 
 const confirmImportOverwrite = async (): Promise<boolean> => {
   if (!hasFormContent.value) {
@@ -738,6 +744,7 @@ const confirmImportOverwrite = async (): Promise<boolean> => {
 
 const checkInfo = async (): Promise<void> => {
   const urls = splitUrls(form.url || '');
+  timerError.value = '';
 
   if (formError.value) {
     return;
@@ -758,8 +765,8 @@ const checkInfo = async (): Promise<void> => {
 
   try {
     await requireTimerForTask(form);
-  } catch (error: any) {
-    toast.error(error.message);
+  } catch (error) {
+    timerError.value = error instanceof Error ? error.message : t('common.unknownError');
     return;
   }
 
@@ -798,8 +805,8 @@ const checkInfo = async (): Promise<void> => {
 
   try {
     await Promise.all(tasks.map((item) => requireTimerForTask(item)));
-  } catch (error: any) {
-    toast.error(error.message);
+  } catch (error) {
+    timerError.value = error instanceof Error ? error.message : t('common.unknownError');
     return;
   }
 

--- a/ui/app/composables/useConditions.ts
+++ b/ui/app/composables/useConditions.ts
@@ -1,7 +1,7 @@
 import { ref, readonly } from 'vue';
 
 import { useNotification } from '~/composables/useNotification';
-import { request, parse_list_response, parse_api_response, parse_api_error } from '~/utils';
+import { request, parse_list_response, parse_api_response, ensure_api_success } from '~/utils';
 import type {
   Condition,
   ConditionTestRequest,
@@ -69,41 +69,17 @@ const sortConditions = (items: Array<Condition>): Array<Condition> => {
 };
 
 /**
- * Safely reads JSON from a Response, returns null on error.
- * @param response Fetch Response object
- * @returns Parsed JSON or null
- */
-const readJson = async (response: Response): Promise<unknown> => {
-  try {
-    const clone = response.clone();
-    return await clone.json();
-  } catch {
-    return null;
-  }
-};
-
-/**
- * Throws an error if the response is not OK, using API error message if available.
- * @param response Fetch Response object
- * @throws Error with message from API or status code
- */
-const ensureSuccess = async (response: Response): Promise<void> => {
-  if (response.ok) {
-    return;
-  }
-
-  const payload = await readJson(response);
-  const message = await parse_api_error(payload);
-  throw new Error(message);
-};
-
-/**
  * Handles errors by updating lastError and showing a notification.
  * @param error Error object or unknown
  */
-const handleError = (error: unknown): void => {
+const setError = (error: unknown): string => {
   const message = error instanceof Error ? error.message : t('common.unknownError');
   lastError.value = message;
+  return message;
+};
+
+const handleError = (error: unknown): void => {
+  const message = setError(error);
   useNotification().error(message);
 };
 
@@ -153,7 +129,7 @@ const loadConditions = async (
       url += `&per_page=${perPage}`;
     }
     const response = await request(url);
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const { items, pagination: paginationData } = await parse_list_response<Condition>(json);
@@ -177,7 +153,7 @@ const loadConditions = async (
 const getCondition = async (id: number): Promise<Condition | null> => {
   try {
     const response = await request(`/api/conditions/${id}`);
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const condition = await parse_api_response<Condition>(json);
@@ -208,7 +184,7 @@ const createCondition = async (
       body: JSON.stringify(condition),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const created = await parse_api_response<Condition>(json);
@@ -224,14 +200,13 @@ const createCondition = async (
     return created;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -259,7 +234,7 @@ const updateCondition = async (
       body: JSON.stringify(condition),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const updated = await parse_api_response<Condition>(json);
@@ -277,14 +252,13 @@ const updateCondition = async (
     return updated;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -312,7 +286,7 @@ const patchCondition = async (
       body: JSON.stringify(patch),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const updated = await parse_api_response<Condition>(json);
@@ -330,14 +304,13 @@ const patchCondition = async (
     return updated;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -355,7 +328,7 @@ const deleteCondition = async (
 ): Promise<boolean> => {
   try {
     const response = await request(`/api/conditions/${id}`, { method: 'DELETE' });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     removeCondition(id);
     useNotification().success(t('common.crudDeleted', { type: t('conditions.condition') }));
@@ -393,7 +366,7 @@ const testCondition = async (
       body: JSON.stringify(testRequest),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const result = await parse_api_response<ConditionTestResponse>(json);

--- a/ui/app/composables/useDlFields.ts
+++ b/ui/app/composables/useDlFields.ts
@@ -1,7 +1,7 @@
 import { ref, readonly } from 'vue';
 
 import { useNotification } from '~/composables/useNotification';
-import { request, parse_list_response, parse_api_response, parse_api_error } from '~/utils';
+import { request, parse_list_response, parse_api_response, ensure_api_success } from '~/utils';
 import type { DLField, DLFieldRequest } from '~/types/dl_fields';
 import type { APIResponse, Pagination } from '~/types/responses';
 
@@ -59,41 +59,17 @@ const sortDlFields = (items: Array<DLField>): Array<DLField> => {
 };
 
 /**
- * Safely reads JSON from a Response, returns null on error.
- * @param response Fetch Response object
- * @returns Parsed JSON or null
- */
-const readJson = async (response: Response): Promise<unknown> => {
-  try {
-    const clone = response.clone();
-    return await clone.json();
-  } catch {
-    return null;
-  }
-};
-
-/**
- * Throws an error if the response is not OK, using API error message if available.
- * @param response Fetch Response object
- * @throws Error with message from API or status code
- */
-const ensureSuccess = async (response: Response): Promise<void> => {
-  if (response.ok) {
-    return;
-  }
-
-  const payload = await readJson(response);
-  const message = await parse_api_error(payload);
-  throw new Error(message);
-};
-
-/**
  * Handles errors by updating lastError and showing a notification.
  * @param error Error object or unknown
  */
-const handleError = (error: unknown): void => {
+const setError = (error: unknown): string => {
   const message = error instanceof Error ? error.message : t('common.unknownError');
   lastError.value = message;
+  return message;
+};
+
+const handleError = (error: unknown): void => {
+  const message = setError(error);
   notify.error(message);
 };
 
@@ -140,7 +116,7 @@ const loadDlFields = async (
       url += `&per_page=${perPage}`;
     }
     const response = await request(url);
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const { items, pagination: paginationData } = await parse_list_response<DLField>(json);
@@ -164,7 +140,7 @@ const loadDlFields = async (
 const getDlField = async (id: number): Promise<DLField | null> => {
   try {
     const response = await request(`/api/dl_fields/${id}`);
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const field = await parse_api_response<DLField>(json);
@@ -195,7 +171,7 @@ const createDlField = async (
       body: JSON.stringify(field),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const created = await parse_api_response<DLField>(json);
@@ -211,14 +187,13 @@ const createDlField = async (
     return created;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -246,7 +221,7 @@ const updateDlField = async (
       body: JSON.stringify(field),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const updated = await parse_api_response<DLField>(json);
@@ -262,14 +237,13 @@ const updateDlField = async (
     return updated;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -297,7 +271,7 @@ const patchDlField = async (
       body: JSON.stringify(patch),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const updated = await parse_api_response<DLField>(json);
@@ -313,14 +287,13 @@ const patchDlField = async (
     return updated;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -338,7 +311,7 @@ const deleteDlField = async (
 ): Promise<boolean> => {
   try {
     const response = await request(`/api/dl_fields/${id}`, { method: 'DELETE' });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     removeDlField(id);
     notify.success(t('common.crudDeleted', { type: t('customFields.field') }));

--- a/ui/app/composables/useFormSubmit.ts
+++ b/ui/app/composables/useFormSubmit.ts
@@ -1,0 +1,36 @@
+import { computed, ref } from 'vue';
+
+import { to_api_error, type ApiError } from '~/utils';
+
+export const useFormSubmit = () => {
+  const error = ref<ApiError | null>(null);
+  const message = computed(() => error.value?.message ?? '');
+  const fields = computed(() => error.value?.fields ?? {});
+
+  const clear = (): void => {
+    error.value = null;
+  };
+
+  const setError = (reason: unknown): void => {
+    error.value = to_api_error(reason);
+  };
+
+  const run = async <T>(action: () => Promise<T>): Promise<T | null> => {
+    clear();
+    try {
+      return await action();
+    } catch (reason) {
+      setError(reason);
+      return null;
+    }
+  };
+
+  return {
+    error,
+    message,
+    fields,
+    clear,
+    setError,
+    run,
+  };
+};

--- a/ui/app/composables/useNotifications.ts
+++ b/ui/app/composables/useNotifications.ts
@@ -1,7 +1,7 @@
 import { ref, readonly } from 'vue';
 
 import { useNotification } from '~/composables/useNotification';
-import { request, parse_list_response, parse_api_response, parse_api_error } from '~/utils';
+import { request, parse_list_response, parse_api_response, ensure_api_success } from '~/utils';
 import type { notification } from '~/types/notification';
 import type { APIResponse, Pagination } from '~/types/responses';
 
@@ -57,41 +57,17 @@ const sortNotifications = (items: Array<notification>): Array<notification> => {
 };
 
 /**
- * Safely reads JSON from a Response, returns null on error.
- * @param response Fetch Response object
- * @returns Parsed JSON or null
- */
-const readJson = async (response: Response): Promise<unknown> => {
-  try {
-    const clone = response.clone();
-    return await clone.json();
-  } catch {
-    return null;
-  }
-};
-
-/**
- * Throws an error if the response is not OK, using API error message if available.
- * @param response Fetch Response object
- * @throws Error with message from API or status code
- */
-const ensureSuccess = async (response: Response): Promise<void> => {
-  if (response.ok) {
-    return;
-  }
-
-  const payload = await readJson(response);
-  const message = await parse_api_error(payload);
-  throw new Error(message);
-};
-
-/**
  * Handles errors by updating lastError and showing a notification.
  * @param error Error object or unknown
  */
-const handleError = (error: unknown): void => {
+const setError = (error: unknown): string => {
   const message = error instanceof Error ? error.message : t('common.unknownError');
   lastError.value = message;
+  return message;
+};
+
+const handleError = (error: unknown): void => {
+  const message = setError(error);
   notify.error(message);
 };
 
@@ -142,7 +118,7 @@ const loadNotifications = async (
       url += `&per_page=${perPage}`;
     }
     const response = await request(url);
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const { items, pagination: paginationData } = await parse_list_response<notification>(json);
@@ -168,7 +144,7 @@ const loadNotificationEvents = async (): Promise<void> => {
 
   try {
     const response = await request('/api/notifications/events/');
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     events.value = Array.isArray(json?.events) ? json.events : [];
@@ -187,7 +163,7 @@ const loadNotificationEvents = async (): Promise<void> => {
 const getNotification = async (id: number): Promise<notification | null> => {
   try {
     const response = await request(`/api/notifications/${id}`);
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const item = await parse_api_response<notification>(json);
@@ -217,7 +193,7 @@ const createNotification = async (
       method: 'POST',
       body: JSON.stringify(item),
     });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const created = await parse_api_response<notification>(json);
@@ -233,14 +209,13 @@ const createNotification = async (
     return created;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -267,7 +242,7 @@ const updateNotification = async (
       method: 'PUT',
       body: JSON.stringify(item),
     });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const updated = await parse_api_response<notification>(json);
@@ -285,14 +260,13 @@ const updateNotification = async (
     return updated;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -319,7 +293,7 @@ const patchNotification = async (
       method: 'PATCH',
       body: JSON.stringify(patch),
     });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const updated = await parse_api_response<notification>(json);
@@ -337,14 +311,13 @@ const patchNotification = async (
     return updated;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -362,7 +335,7 @@ const deleteNotification = async (
 ): Promise<boolean> => {
   try {
     const response = await request(`/api/notifications/${id}`, { method: 'DELETE' });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     removeNotification(id);
     notify.success(t('common.crudDeleted', { type: t('notificationsPage.target') }));

--- a/ui/app/composables/usePresetEditor.ts
+++ b/ui/app/composables/usePresetEditor.ts
@@ -36,6 +36,7 @@ const sanitizePreset = (item: Preset | EditablePreset): Partial<Preset> => {
 export const usePresetEditor = () => {
   const { t } = useI18n();
   const presetsStore = usePresets();
+  const submission = useFormSubmit();
 
   const isOpen = ref(false);
   const reference = ref<number | null>(null);
@@ -44,6 +45,7 @@ export const usePresetEditor = () => {
   const sessionId = ref(0);
 
   const discardEditor = (): void => {
+    submission.clear();
     dirty.value = false;
     reference.value = null;
     preset.value = makeEmptyPreset();
@@ -114,14 +116,16 @@ export const usePresetEditor = () => {
     const cleaned = sanitizePreset(currentPreset) as Preset;
 
     if (currentReference) {
-      const updated = await presetsStore.updatePreset(currentReference, cleaned);
+      const updated = await submission.run(() =>
+        presetsStore.updatePreset(currentReference, cleaned as Preset),
+      );
       if (updated) {
         close();
       }
       return updated;
     }
 
-    const created = await presetsStore.createPreset(cleaned);
+    const created = await submission.run(() => presetsStore.createPreset(cleaned));
     if (created) {
       close();
     }
@@ -138,6 +142,7 @@ export const usePresetEditor = () => {
     isDirty,
     dirty,
     addInProgress: presetsStore.addInProgress,
+    submitError: submission.message,
     openCreate,
     openEdit,
     close,

--- a/ui/app/composables/usePresets.ts
+++ b/ui/app/composables/usePresets.ts
@@ -1,7 +1,7 @@
 import { ref, readonly } from 'vue';
 
 import { useNotification } from '~/composables/useNotification';
-import { request, parse_list_response, parse_api_response, parse_api_error } from '~/utils';
+import { request, parse_list_response, parse_api_response, ensure_api_success } from '~/utils';
 import type { Preset, PresetRequest } from '~/types/presets';
 import type { APIResponse, Pagination } from '~/types/responses';
 
@@ -60,41 +60,17 @@ const sortPresets = (items: Array<Preset>): Array<Preset> => {
 };
 
 /**
- * Safely reads JSON from a Response, returns null on error.
- * @param response Fetch Response object
- * @returns Parsed JSON or null
- */
-const readJson = async (response: Response): Promise<unknown> => {
-  try {
-    const clone = response.clone();
-    return await clone.json();
-  } catch {
-    return null;
-  }
-};
-
-/**
- * Throws an error if the response is not OK, using API error message if available.
- * @param response Fetch Response object
- * @throws Error with message from API or status code
- */
-const ensureSuccess = async (response: Response): Promise<void> => {
-  if (response.ok) {
-    return;
-  }
-
-  const payload = await readJson(response);
-  const message = await parse_api_error(payload);
-  throw new Error(message);
-};
-
-/**
  * Handles errors by updating lastError and showing a notification.
  * @param error Error object or unknown
  */
-const handleError = (error: unknown): void => {
+const setError = (error: unknown): string => {
   const message = error instanceof Error ? error.message : t('common.unknownError');
   lastError.value = message;
+  return message;
+};
+
+const handleError = (error: unknown): void => {
+  const message = setError(error);
   useNotification().error(message);
 };
 
@@ -146,7 +122,7 @@ const loadPresets = async (
     }
 
     const response = await request(url);
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const { items, pagination: paginationData } = await parse_list_response<Preset>(json);
@@ -170,7 +146,7 @@ const loadPresets = async (
 const getPreset = async (id: number): Promise<Preset | null> => {
   try {
     const response = await request(`/api/presets/${id}`);
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const preset = await parse_api_response<Preset>(json);
@@ -201,7 +177,7 @@ const createPreset = async (
       body: JSON.stringify(preset),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const created = await parse_api_response<Preset>(json);
@@ -217,14 +193,13 @@ const createPreset = async (
     return created;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -256,7 +231,7 @@ const updatePreset = async (
       body: JSON.stringify(payload),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const updated = await parse_api_response<Preset>(json);
@@ -274,14 +249,13 @@ const updatePreset = async (
     return updated;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -313,7 +287,7 @@ const patchPreset = async (
       body: JSON.stringify(payload),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const updated = await parse_api_response<Preset>(json);
@@ -356,7 +330,7 @@ const deletePreset = async (
 ): Promise<boolean> => {
   try {
     const response = await request(`/api/presets/${id}`, { method: 'DELETE' });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     removePreset(id);
     useNotification().success(t('common.crudDeleted', { type: t('common.presetLabel') }));

--- a/ui/app/composables/useTaskDefinitions.ts
+++ b/ui/app/composables/useTaskDefinitions.ts
@@ -1,7 +1,7 @@
 import { ref, readonly } from 'vue';
 
 import { useNotification } from '~/composables/useNotification';
-import { request, parse_list_response, parse_api_response, parse_api_error } from '~/utils';
+import { request, parse_list_response, parse_api_response, ensure_api_success } from '~/utils';
 import type {
   TaskDefinitionDetailed,
   TaskDefinitionDocument,
@@ -61,30 +61,17 @@ const sortSummaries = (items: Array<TaskDefinitionSummary>): Array<TaskDefinitio
 };
 
 /**
- * Throws an error if the response is not OK, using API error message if available.
- * @param response Fetch Response object
- * @throws Error with message from API or status code
- */
-const ensureSuccess = async (response: Response): Promise<void> => {
-  if (response.ok) {
-    return;
-  }
-
-  const payload = await response
-    .clone()
-    .json()
-    .catch(() => null);
-  const message = await parse_api_error(payload);
-  throw new Error(message);
-};
-
-/**
  * Handles errors by updating lastError and showing a notification.
  * @param error Error object or unknown
  */
-const handleError = (error: unknown): void => {
+const setError = (error: unknown): string => {
   const message = error instanceof Error ? error.message : t('common.unknownError');
   lastError.value = message;
+  return message;
+};
+
+const handleError = (error: unknown): void => {
+  const message = setError(error);
   useNotification().error(message);
 };
 
@@ -130,7 +117,7 @@ const loadDefinitions = async (
       url += `&per_page=${perPage}`;
     }
     const response = await request(url);
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const { items, pagination: paginationData } =
@@ -155,7 +142,7 @@ const loadDefinitions = async (
 const getDefinition = async (id: number): Promise<TaskDefinitionDetailed | null> => {
   try {
     const response = await request(`/api/tasks/definitions/${id}`);
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const payload = await response.json();
     const detailed = await parse_api_response<TaskDefinitionDetailed>(payload);
@@ -182,7 +169,7 @@ const createDefinition = async (
       body: JSON.stringify(definition),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const payload = await parse_api_response<TaskDefinitionDetailed>(response.json());
 
@@ -200,9 +187,8 @@ const createDefinition = async (
     lastError.value = null;
     return payload;
   } catch (error) {
-    handleError(error);
-    if (throwInstead.value) throw error;
-    return null;
+    setError(error);
+    throw error;
   }
 };
 
@@ -222,7 +208,7 @@ const updateDefinition = async (
       body: JSON.stringify(definition),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const payload = await parse_api_response<TaskDefinitionDetailed>(response.json());
 
@@ -242,9 +228,8 @@ const updateDefinition = async (
     lastError.value = null;
     return payload;
   } catch (error) {
-    handleError(error);
-    if (throwInstead.value) throw error;
-    return null;
+    setError(error);
+    throw error;
   }
 };
 
@@ -256,7 +241,7 @@ const updateDefinition = async (
 const deleteDefinition = async (id: number): Promise<boolean> => {
   try {
     const response = await request(`/api/tasks/definitions/${id}`, { method: 'DELETE' });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     removeSummary(id);
     useNotification().success(t('common.crudDeleted', { type: t('taskDefinitions.definition') }));
@@ -285,7 +270,7 @@ const toggleEnabled = async (
       body: JSON.stringify({ enabled }),
     });
 
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const payload = await parse_api_response<TaskDefinitionDetailed>(response.json());
 

--- a/ui/app/composables/useTasks.ts
+++ b/ui/app/composables/useTasks.ts
@@ -1,6 +1,6 @@
 import { ref, readonly } from 'vue';
 import { useNotification } from '~/composables/useNotification';
-import { request, parse_list_response, parse_api_response, parse_api_error } from '~/utils';
+import { request, parse_list_response, parse_api_response, ensure_api_success } from '~/utils';
 import type {
   Task,
   TaskPatch,
@@ -63,41 +63,17 @@ const sortTasks = (items: Array<Task>): Array<Task> => {
 };
 
 /**
- * Safely reads JSON from a Response, returns null on error.
- * @param response Fetch Response object
- * @returns Parsed JSON or null
- */
-const readJson = async (response: Response): Promise<unknown> => {
-  try {
-    const clone = response.clone();
-    return await clone.json();
-  } catch {
-    return null;
-  }
-};
-
-/**
- * Throws an error if the response is not OK, using API error message if available.
- * @param response Fetch Response object
- * @throws Error with message from API or status code
- */
-const ensureSuccess = async (response: Response): Promise<void> => {
-  if (response.ok) {
-    return;
-  }
-
-  const payload = await readJson(response);
-  const message = await parse_api_error(payload);
-  throw new Error(message);
-};
-
-/**
  * Handles errors by updating lastError and showing a notification.
  * @param error Error object or unknown
  */
-const handleError = (error: unknown): void => {
+const setError = (error: unknown): string => {
   const message = error instanceof Error ? error.message : t('common.unknownError');
   lastError.value = message;
+  return message;
+};
+
+const handleError = (error: unknown): void => {
+  const message = setError(error);
   useNotification().error(message);
 };
 
@@ -143,7 +119,7 @@ const loadTasks = async (
       url += `&per_page=${perPage}`;
     }
     const response = await request(url);
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const { items, pagination: paginationData } = await parse_list_response<Task>(json);
@@ -167,7 +143,7 @@ const loadTasks = async (
 const getTask = async (id: number): Promise<Task | null> => {
   try {
     const response = await request(`/api/tasks/${id}`);
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const task = await parse_api_response<Task>(json);
@@ -199,7 +175,7 @@ const createTask = async (
       method: 'POST',
       body: JSON.stringify(task),
     });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const created = await parse_api_response<Task | Array<Task>>(json);
@@ -227,14 +203,13 @@ const createTask = async (
     return created;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -261,7 +236,7 @@ const updateTask = async (
       method: 'PUT',
       body: JSON.stringify(taskData),
     });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const updated = await parse_api_response<Task>(json);
@@ -279,14 +254,13 @@ const updateTask = async (
     return updated;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -310,7 +284,7 @@ const patchTask = async (
       method: 'PATCH',
       body: JSON.stringify(patch),
     });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const updated = await parse_api_response<Task>(json);
@@ -328,14 +302,13 @@ const patchTask = async (
     return updated;
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : t('common.unknownError');
-    handleError(error);
+    setError(error);
 
     if (callback) {
       callback({ success: false, error: errorMessage, detail: error, data: undefined });
     }
 
-    if (throwInstead.value) throw error;
-    return null;
+    throw error;
   } finally {
     addInProgress.value = false;
   }
@@ -353,7 +326,7 @@ const deleteTask = async (
 ): Promise<boolean> => {
   try {
     const response = await request(`/api/tasks/${id}`, { method: 'DELETE' });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     removeTask(id);
     useNotification().success(t('common.crudDeleted', { type: t('tasks.task') }));
@@ -409,7 +382,7 @@ const inspectTaskHandler = async (
 const markTaskItems = async (id: number): Promise<string | null> => {
   try {
     const response = await request(`/api/tasks/${id}/mark`, { method: 'POST' });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const message = json.message || t('tasks.allMarkedDownloaded');
@@ -432,7 +405,7 @@ const markTaskItems = async (id: number): Promise<string | null> => {
 const unmarkTaskItems = async (id: number): Promise<string | null> => {
   try {
     const response = await request(`/api/tasks/${id}/mark`, { method: 'DELETE' });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const message = json.message || t('tasks.allRemovedArchive');
@@ -455,7 +428,7 @@ const unmarkTaskItems = async (id: number): Promise<string | null> => {
 const generateTaskMetadata = async (id: number): Promise<TaskMetadataResponse | null> => {
   try {
     const response = await request(`/api/tasks/${id}/metadata`, { method: 'POST' });
-    await ensureSuccess(response);
+    await ensure_api_success(response);
 
     const json = await response.json();
     const metadata = await parse_api_response<TaskMetadataResponse>(json);

--- a/ui/app/pages/conditions.vue
+++ b/ui/app/pages/conditions.vue
@@ -469,6 +469,7 @@
       @update:open="handleEditorOpenChange"
     >
       <template #body>
+        <FormSubmitError :message="submission.message.value" />
         <ConditionForm
           :key="modalKey"
           :addInProgress="conditions.addInProgress.value"
@@ -519,7 +520,6 @@ import { useExpandableMeta } from '~/composables/useExpandableMeta';
 import { useConfirm } from '~/composables/useConfirm';
 import { useConditions } from '~/composables/useConditions';
 import type { Condition } from '~/types/conditions';
-import type { APIResponse } from '~/types/responses';
 import { cleanObject, copyText, encode } from '~/utils';
 import { usePageShell } from '~/composables/usePageShell';
 const { t } = useI18n();
@@ -527,11 +527,13 @@ const { t } = useI18n();
 type ConditionItemWithUI = Condition & { raw?: boolean };
 
 const box = useConfirm();
+const toast = useNotification();
 const pageShell = usePageShell('conditions');
 const displayStyle = useStorage<'list' | 'grid'>('conditions_display_style', 'grid');
 const isMobile = useMediaQuery({ maxWidth: 639 });
 const { toggleExpand, expandClass } = useExpandableMeta();
 const conditions = useConditions();
+const submission = useFormSubmit();
 const route = useRoute();
 const router = useRouter();
 const { confirmDialog } = useDialog();
@@ -657,6 +659,7 @@ const loadContent = async (pageNumber = 1): Promise<void> => {
 };
 
 const resetEditor = (): void => {
+  submission.clear();
   item.value = {};
   itemRef.value = null;
   editorDirty.value = false;
@@ -755,20 +758,17 @@ const updateItem = async ({
   item: Condition;
 }): Promise<void> => {
   updatedItem = cleanObject(updatedItem, removeKeys) as Condition;
-  const callback = (response: APIResponse) => {
-    if (response.success) {
-      closeEditor();
-    }
-  };
+  const result = reference
+    ? await submission.run(() => conditions.patchCondition(reference, updatedItem))
+    : await submission.run(() => conditions.createCondition(updatedItem));
 
-  if (reference) {
-    await conditions.patchCondition(reference, updatedItem, callback);
-  } else {
-    await conditions.createCondition(updatedItem, callback);
+  if (result) {
+    closeEditor();
   }
 };
 
 const editItem = (value: Condition): void => {
+  submission.clear();
   editorDirty.value = false;
   item.value = JSON.parse(JSON.stringify(value)) as Condition;
   itemRef.value = value.id;
@@ -776,7 +776,11 @@ const editItem = (value: Condition): void => {
 };
 
 const toggleEnabled = async (cond: Condition): Promise<void> => {
-  await conditions.patchCondition(cond.id!, { enabled: !cond.enabled });
+  try {
+    await conditions.patchCondition(cond.id!, { enabled: !cond.enabled });
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : t('common.unknownError'));
+  }
 };
 
 const exportItem = (cond: Condition): void => {

--- a/ui/app/pages/dl_fields.vue
+++ b/ui/app/pages/dl_fields.vue
@@ -410,6 +410,7 @@
       @update:open="handleEditorOpenChange"
     >
       <template #body>
+        <FormSubmitError :message="submission.message.value" />
         <DLFieldForm
           :key="modalKey"
           :addInProgress="dlFields.addInProgress.value"
@@ -460,7 +461,6 @@ import { useExpandableMeta } from '~/composables/useExpandableMeta';
 import { useConfirm } from '~/composables/useConfirm';
 import { useDlFields } from '~/composables/useDlFields';
 import type { DLField } from '~/types/dl_fields';
-import type { APIResponse } from '~/types/responses';
 import { copyText, encode } from '~/utils';
 import { usePageShell } from '~/composables/usePageShell';
 const { t } = useI18n();
@@ -471,6 +471,7 @@ const pageShell = usePageShell('custom-fields');
 const displayStyle = useStorage<'list' | 'grid'>('dl_fields_display_style', 'grid');
 const isMobile = useMediaQuery({ maxWidth: 639 });
 const dlFields = useDlFields();
+const submission = useFormSubmit();
 const route = useRoute();
 const router = useRouter();
 const { confirmDialog } = useDialog();
@@ -594,6 +595,7 @@ const loadContent = async (pageNumber = 1): Promise<void> => {
 };
 
 const resetEditor = (): void => {
+  submission.clear();
   item.value = {};
   itemRef.value = null;
   editorDirty.value = false;
@@ -683,20 +685,17 @@ const updateItem = async ({
   reference: number | null | undefined;
   item: DLField;
 }): Promise<void> => {
-  const callback = (response: APIResponse) => {
-    if (response.success) {
-      closeEditor();
-    }
-  };
+  const result = reference
+    ? await submission.run(() => dlFields.patchDlField(reference, updatedItem))
+    : await submission.run(() => dlFields.createDlField(updatedItem));
 
-  if (reference) {
-    await dlFields.patchDlField(reference, updatedItem, callback);
-  } else {
-    await dlFields.createDlField(updatedItem, callback);
+  if (result) {
+    closeEditor();
   }
 };
 
 const editItem = (field: DLField): void => {
+  submission.clear();
   editorDirty.value = false;
   item.value = JSON.parse(JSON.stringify(field)) as DLField;
   itemRef.value = field.id;

--- a/ui/app/pages/notifications.vue
+++ b/ui/app/pages/notifications.vue
@@ -547,6 +547,7 @@
       @update:open="handleEditorOpenChange"
     >
       <template #body>
+        <FormSubmitError :message="submission.message.value" />
         <NotificationForm
           :key="modalKey"
           :addInProgress="addInProgress"
@@ -615,12 +616,12 @@ const displayStyleState = useStorage<'list' | 'grid' | 'cards'>(
 const isMobile = useMediaQuery({ maxWidth: 639 });
 
 const notificationsStore = useNotifications();
+const submission = useFormSubmit();
 const notifications = notificationsStore.notifications;
 const paging = notificationsStore.pagination;
 const allowedEvents = notificationsStore.events;
 const isLoading = notificationsStore.isLoading;
 const addInProgress = notificationsStore.addInProgress;
-const lastError = notificationsStore.lastError;
 
 const page = ref(1);
 const targetRef = ref<number | undefined>(undefined);
@@ -740,6 +741,7 @@ const loadContent = async (pageNumber = page.value): Promise<void> => {
 };
 
 const resetEditor = (): void => {
+  submission.clear();
   target.value = defaultState();
   targetRef.value = undefined;
   editorDirty.value = false;
@@ -766,6 +768,7 @@ const toggleMasterSelection = (): void => {
 };
 
 const editItem = (item: notification): void => {
+  submission.clear();
   editorDirty.value = false;
   target.value = JSON.parse(JSON.stringify(item)) as notification;
   targetRef.value = item.id ?? undefined;
@@ -836,7 +839,11 @@ const toggleEnabled = async (item: notification): Promise<void> => {
     return;
   }
 
-  await notificationsStore.patchNotification(item.id, { enabled: !item.enabled });
+  try {
+    await notificationsStore.patchNotification(item.id, { enabled: !item.enabled });
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : t('common.unknownError'));
+  }
 };
 
 const updateItem = async ({
@@ -846,13 +853,11 @@ const updateItem = async ({
   reference: number | undefined;
   item: notification;
 }): Promise<void> => {
-  if (reference) {
-    await notificationsStore.updateNotification(reference, item);
-  } else {
-    await notificationsStore.createNotification(item);
-  }
+  const result = reference
+    ? await submission.run(() => notificationsStore.updateNotification(reference, item))
+    : await submission.run(() => notificationsStore.createNotification(item));
 
-  if (!lastError.value) {
+  if (result) {
     closeEditor();
   }
 };

--- a/ui/app/pages/presets.vue
+++ b/ui/app/pages/presets.vue
@@ -459,6 +459,7 @@
       @update:open="(open) => void editor.handleOpenChange(open)"
     >
       <template #body>
+        <FormSubmitError :message="editor.submitError.value" />
         <PresetForm
           :key="editor.modalKey.value"
           :addInProgress="editor.addInProgress.value"

--- a/ui/app/pages/simple.vue
+++ b/ui/app/pages/simple.vue
@@ -17,6 +17,7 @@
             <div class="mx-auto w-full transition-all duration-300" :class="formContainerClass">
               <div class="ytp-card p-4 sm:p-5">
                 <form autocomplete="off" class="space-y-4" @submit.prevent="addDownload">
+                  <FormSubmitError :message="submitError" />
                   <div class="flex items-start justify-between gap-3">
                     <div class="min-w-0 space-y-1">
                       <div class="flex items-center gap-2 text-base font-semibold text-highlighted">
@@ -836,6 +837,7 @@ const videoOpen = computed<boolean>({
 const formUrl = ref('');
 const formPreset = ref(app.value.default_preset || '');
 const addInProgress = ref(false);
+const submitError = ref('');
 const showExtras = ref(false);
 const isRefreshing = ref(false);
 const historyInitialized = ref(false);
@@ -960,9 +962,10 @@ const stopAutoRefresh = (): void => {
 
 const addDownload = async (): Promise<void> => {
   const url = formUrl.value.trim();
+  submitError.value = '';
 
   if (!url) {
-    toast.error(t('common.enterValidUrl'));
+    submitError.value = t('common.enterValidUrl');
     return;
   }
 
@@ -1027,11 +1030,14 @@ const addDownload = async (): Promise<void> => {
     const data = await response.json();
 
     if (!response.ok) {
-      toast.error(t('common.errorPrefix', { msg: data?.error || t('queue.failedToAdd') }));
+      submitError.value = t('common.errorPrefix', {
+        msg: data?.error || t('queue.failedToAdd'),
+      });
       return;
     }
 
     let had_errors = false;
+    const errors: string[] = [];
 
     if (200 === response.status && Array.isArray(data)) {
       data.forEach((item: Record<string, any>) => {
@@ -1045,9 +1051,12 @@ const addDownload = async (): Promise<void> => {
           return;
         }
 
-        toast.error(t('common.errorPrefix', { msg: item.msg || t('queue.failedToAdd') }));
+        const message = t('common.errorPrefix', { msg: item.msg || t('queue.failedToAdd') });
+        errors.push(message);
       });
     }
+
+    submitError.value = errors.join('\n');
 
     if (202 === response.status) {
       toast.success(data.message, { timeout: 2000 });
@@ -1060,7 +1069,7 @@ const addDownload = async (): Promise<void> => {
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : t('queue.failedToAdd');
-    toast.error(t('common.errorPrefix', { msg: message }));
+    submitError.value = t('common.errorPrefix', { msg: message });
   } finally {
     addInProgress.value = false;
   }

--- a/ui/app/pages/task_definitions.vue
+++ b/ui/app/pages/task_definitions.vue
@@ -428,6 +428,7 @@
       @update:open="handleEditorOpenChange"
     >
       <template #body>
+        <FormSubmitError :message="submission.message.value" />
         <TaskDefinitionEditor
           ref="definitionEditor"
           :document="workingDefinition"
@@ -600,6 +601,7 @@ const pageShell = usePageShell('task-definitions');
 const { toggleExpand, expandClass } = useExpandableMeta();
 
 const taskDefs = useTaskDefinitionsComposable();
+const submission = useFormSubmit();
 const definitionsRef = taskDefs.definitions;
 const isLoading = taskDefs.isLoading;
 const lastError = taskDefs.lastError;
@@ -760,6 +762,7 @@ const toggleMasterSelection = (): void => {
 };
 
 const openCreate = (): void => {
+  submission.clear();
   editorDirty.value = false;
   editorValid.value = false;
   editorMode.value = 'create';
@@ -772,6 +775,7 @@ const openCreate = (): void => {
 };
 
 const openEdit = async (summary: TaskDefinitionSummary): Promise<void> => {
+  submission.clear();
   editorDirty.value = false;
   editorValid.value = false;
   editorMode.value = 'edit';
@@ -826,6 +830,7 @@ const closeEditor = (): void => {
   }
 
   editorDirty.value = false;
+  submission.clear();
   editorValid.value = false;
   isEditorOpen.value = false;
   workingDefinition.value = null;
@@ -841,12 +846,13 @@ const submitDefinition = async (definition: TaskDefinitionDocument): Promise<voi
 
   try {
     if (editorMode.value === 'create') {
-      const created = await createDefinition(definition);
+      const created = await submission.run(() => createDefinition(definition));
       if (created) {
         shouldClose = true;
       }
     } else if (workingId.value) {
-      const updated = await updateDefinition(workingId.value, definition);
+      const id = workingId.value;
+      const updated = await submission.run(() => updateDefinition(id, definition));
       if (updated) {
         shouldClose = true;
       }

--- a/ui/app/pages/tasks.vue
+++ b/ui/app/pages/tasks.vue
@@ -692,6 +692,7 @@
       @update:open="handleEditorOpenChange"
     >
       <template #body>
+        <FormSubmitError :message="submission.message.value" />
         <TaskForm
           :key="formKey"
           :addInProgress="addInProgress"
@@ -807,6 +808,7 @@ const display_style = useStorage<'list' | 'grid' | 'cards'>('tasks_display_style
 const isMobile = useMediaQuery({ maxWidth: 639 });
 
 const tasksComposable = useTasks();
+const submission = useFormSubmit();
 const {
   tasks,
   pagination: paging,
@@ -1058,6 +1060,7 @@ const loadContent = async (pageNumber = page.value, fromMounted: boolean = false
 };
 
 const resetForm = (closeForm: boolean = false) => {
+  submission.clear();
   task.value = createEmptyTask();
   taskRef.value = null;
   editorDirty.value = false;
@@ -1147,7 +1150,13 @@ const toggleFlag = async (item: Task, field: 'enabled' | 'auto_start' | 'handler
   }
 
   const currentValue = item[field] !== false;
-  const updated = await tasksComposable.patchTask(item.id, { [field]: !currentValue });
+  let updated: Task | null = null;
+  try {
+    updated = await tasksComposable.patchTask(item.id, { [field]: !currentValue });
+  } catch (error) {
+    toast.error(error instanceof Error ? error.message : t('common.unknownError'));
+    return;
+  }
 
   if (updated) {
     item[field] = updated[field];
@@ -1171,13 +1180,9 @@ const updateItem = async ({
   task: Task | Task[];
   archive_all?: boolean;
 }) => {
-  let createdOrUpdated: Task | Task[] | null = null;
-
-  if (reference) {
-    createdOrUpdated = await tasksComposable.updateTask(reference, task as Task);
-  } else {
-    createdOrUpdated = await tasksComposable.createTask(task);
-  }
+  const createdOrUpdated = reference
+    ? await submission.run(() => tasksComposable.updateTask(reference, task as Task))
+    : await submission.run(() => tasksComposable.createTask(task));
 
   if (!createdOrUpdated) {
     return;
@@ -1207,6 +1212,7 @@ const updateItem = async ({
 };
 
 const editItem = (item: Task) => {
+  submission.clear();
   editorDirty.value = false;
   editorValid.value = false;
   task.value = { ...item };

--- a/ui/app/utils/index.ts
+++ b/ui/app/utils/index.ts
@@ -1,5 +1,5 @@
 import { useStorage } from '@vueuse/core';
-import type { convert_args_response, Paginated } from '~/types/responses';
+import type { ApiErrorPayload, convert_args_response, Paginated } from '~/types/responses';
 import type { StoreItem } from '~/types/store';
 
 const AG_SEPARATOR = '.';
@@ -1034,6 +1034,65 @@ const parse_api_error = async (json: unknown): Promise<string> => {
   return t('common.unknownError');
 };
 
+class ApiError extends Error {
+  readonly status: number;
+  readonly payload: ApiErrorPayload | null;
+  readonly fields: Record<string, string>;
+
+  constructor(
+    message: string,
+    options: {
+      status?: number;
+      payload?: ApiErrorPayload | null;
+      cause?: unknown;
+    } = {},
+  ) {
+    super(message, { cause: options.cause });
+    this.name = 'ApiError';
+    this.status = options.status ?? 0;
+    this.payload = options.payload ?? null;
+    this.fields = {};
+
+    if (Array.isArray(this.payload?.detail)) {
+      for (const item of this.payload.detail) {
+        const field = item.loc?.at(-1);
+        if (field !== undefined && item.msg) {
+          this.fields[String(field)] = item.msg;
+        }
+      }
+    }
+  }
+}
+
+const to_api_error = (error: unknown): ApiError => {
+  if (error instanceof ApiError) {
+    return error;
+  }
+
+  const { $i18n } = useNuxtApp();
+  const t = $i18n?.t ?? ((key: string) => key);
+  const message = error instanceof Error ? error.message : t('common.unknownError');
+  return new ApiError(message, { cause: error });
+};
+
+const ensure_api_success = async (response: Response): Promise<void> => {
+  if (response.ok) {
+    return;
+  }
+
+  let payload: ApiErrorPayload | null = null;
+  try {
+    payload = (await response.clone().json()) as ApiErrorPayload;
+  } catch {
+    // The status still provides useful context when the response has no JSON body.
+  }
+
+  throw new ApiError(await parse_api_error(payload), {
+    status: response.status,
+    payload,
+  });
+};
+
 const formatPageTitle = (title?: string | null): string => {
   const normalized = title?.trim();
 
@@ -1095,5 +1154,8 @@ export {
   parse_list_response,
   parse_api_response,
   parse_api_error,
+  ApiError,
+  to_api_error,
+  ensure_api_success,
   formatPageTitle,
 };

--- a/ui/tests/composables/useFormSubmit.test.ts
+++ b/ui/tests/composables/useFormSubmit.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test';
+
+import { useFormSubmit } from '~/composables/useFormSubmit';
+import { ApiError } from '~/utils';
+
+describe('useFormSubmit', () => {
+  it('keeps_error_local', async () => {
+    const submit = useFormSubmit();
+    const error = new ApiError('Invalid task.', {
+      status: 422,
+      payload: {
+        detail: [{ loc: ['body', 'timer'], msg: 'Timer is required.' }],
+      },
+    });
+
+    const result = await submit.run(async () => Promise.reject(error));
+
+    expect(result).toBeNull();
+    expect(submit.message.value).toBe('Invalid task.');
+    expect(submit.fields.value).toEqual({ timer: 'Timer is required.' });
+  });
+
+  it('clears_before_retry', async () => {
+    const submit = useFormSubmit();
+    await submit.run(async () => Promise.reject(new Error('Failed.')));
+
+    const result = await submit.run(async () => 'saved');
+
+    expect(result).toBe('saved');
+    expect(submit.error.value).toBeNull();
+  });
+
+  it('clears_on_close', async () => {
+    const submit = useFormSubmit();
+    await submit.run(async () => Promise.reject(new Error('Failed.')));
+
+    submit.clear();
+
+    expect(submit.message.value).toBe('');
+    expect(submit.error.value).toBeNull();
+  });
+
+  it('sets_local_error', () => {
+    const submit = useFormSubmit();
+
+    submit.setError(new Error('Invalid import.'));
+
+    expect(submit.message.value).toBe('Invalid import.');
+  });
+});

--- a/ui/tests/composables/useTasks.test.ts
+++ b/ui/tests/composables/useTasks.test.ts
@@ -272,12 +272,13 @@ describe('useTasks', () => {
       const newTask = { ...mockTask }
       delete (newTask as any).id
 
-      const result = await tasks.createTask(newTask)
-
-      expect(result).toBeNull()
+      await expect(tasks.createTask(newTask)).rejects.toThrow(
+        'Task requires a timer when no supported handler matches the URL.',
+      )
       expect(tasks.lastError.value).toBe(
         'Task requires a timer when no supported handler matches the URL.',
       )
+      expect(errorMock).not.toHaveBeenCalled()
       requestSpy.mockRestore()
     })
 
@@ -316,9 +317,9 @@ describe('useTasks', () => {
       const tasks = useTasks()
       const updated = { ...mockTask, timer: '', handler_enabled: false }
 
-      const result = await tasks.updateTask(1, updated)
-
-      expect(result).toBeNull()
+      await expect(tasks.updateTask(1, updated)).rejects.toThrow(
+        'Task requires a timer when the handler is disabled.',
+      )
       expect(tasks.lastError.value).toBe('Task requires a timer when the handler is disabled.')
       requestSpy.mockRestore()
     })
@@ -372,9 +373,9 @@ describe('useTasks', () => {
       )
 
       const tasks = useTasks()
-      const result = await tasks.patchTask(1, { timer: '' })
-
-      expect(result).toBeNull()
+      await expect(tasks.patchTask(1, { timer: '' })).rejects.toThrow(
+        'Task requires a timer when no supported handler matches the URL.',
+      )
       expect(tasks.lastError.value).toBe(
         'Task requires a timer when no supported handler matches the URL.',
       )
@@ -676,13 +677,13 @@ describe('useTasks', () => {
 
       const tasks = useTasks()
       tasks.clearError()
-      
+
       const newTask = { ...mockTask, name: '', url: '' }
       delete (newTask as any).id
 
-      const result = await tasks.createTask(newTask)
-
-      expect(result).toBeNull()
+      await expect(tasks.createTask(newTask)).rejects.toThrow(
+        'name: Field required, url: Invalid URL format',
+      )
       expect(tasks.lastError.value).toBe('name: Field required, url: Invalid URL format')
       expect(tasks.lastError.value).toContain('name: Field required')
       expect(tasks.lastError.value).toContain('url: Invalid URL format')
@@ -730,7 +731,7 @@ describe('useTasks', () => {
       const newTask = { ...mockTask }
       delete (newTask as any).id
 
-      await tasks.createTask(newTask)
+      await expect(tasks.createTask(newTask)).rejects.toThrow('Bad request')
 
       expect(tasks.addInProgress.value).toBe(false)
       requestSpy.mockRestore()

--- a/ui/tests/utils/index.test.ts
+++ b/ui/tests/utils/index.test.ts
@@ -479,6 +479,29 @@ describe('network and id helpers', () => {
     expect(message).toBe("Failed to fetch RSS/Atom feed. - Client error '404 Not Found'");
   });
 
+  it('preserve_api_error_fields', async () => {
+    const payload = {
+      message: 'Validation failed.',
+      detail: [{ loc: ['body', 'timer'], msg: 'Timer is required.', type: 'value_error' }],
+    };
+    const response = {
+      ok: false,
+      status: 422,
+      clone: () => ({ json: async () => payload }),
+    } as unknown as Response;
+
+    try {
+      await utils.ensure_api_success(response);
+      throw new Error('Expected ensure_api_success to throw');
+    } catch (error) {
+      expect(error).toBeInstanceOf(utils.ApiError);
+      expect((error as InstanceType<typeof utils.ApiError>).status).toBe(422);
+      expect((error as InstanceType<typeof utils.ApiError>).fields).toEqual({
+        timer: 'Timer is required.',
+      });
+    }
+  });
+
   it('prefix_base_url', async () => {
     const responseMock = { status: 200 } as Response;
     fetchMock.mockResolvedValue(responseMock);


### PR DESCRIPTION
This pull request focuses on improving error handling and user feedback across several frontend components, as well as updating documentation and some code cleanup. The main theme is to centralize and standardize how errors are displayed to users, replacing ad-hoc toast notifications with dedicated error display components. Additionally, the documentation is updated for language support, and some minor refactoring is performed.