### PR TITLE
fix: prevent path traversal in file browser rename action

### DIFF
--- a/API.md
+++ b/API.md
@@ -645,7 +645,7 @@ or an error:
 ```
 
 **Error Responses**:
-- `400 Bad Request` if `id` or `new_name` is missing, or the item has no downloaded file.
+- `400 Bad Request` if `id` or `new_name` is missing, `new_name` is not a filename, or the item has no downloaded file.
 - `404 Not Found` if the item does not exist.
 - `409 Conflict` if the rename destination already exists.
 - `500 Internal Server Error` if the filesystem rename fails unexpectedly.
@@ -1928,7 +1928,7 @@ GET /api/file/browser/videos?sort_by=date&sort_order=desc
 ```
 
 Actions and required fields:
-- `rename`: `{ "action": "rename", "path": "...", "new_name": "<name>" }`
+- `rename`: `{ "action": "rename", "path": "...", "new_name": "<name>" }`. `new_name` must be a filename without path separators.
 - `delete`: `{ "action": "delete", "path": "..." }`
 - `move`: `{ "action": "move", "path": "...", "new_path": "<dir-relative-to-download_path>" }`
 - `directory`: `{ "action": "directory", "path": "...", "new_dir": "<subdir/to/create>" }`

--- a/app/library/Utils.py
+++ b/app/library/Utils.py
@@ -680,6 +680,14 @@ def rename_file(old_path: Path, new_name: str) -> tuple[Path, list[tuple[Path, P
 
     """
     new_path: Path = old_path.parent / new_name
+    name_parts = Path(new_name).parts
+    try:
+        valid_parent = new_path.resolve(strict=False).parent == old_path.parent.resolve()
+    except (OSError, ValueError):
+        valid_parent = False
+    if not new_name or name_parts != (new_name,) or not valid_parent:
+        msg = "New name must not contain path separators."
+        raise ValueError(msg)
 
     if new_path.exists():
         msg: str = f"Destination '{new_name}' already exists"
@@ -922,13 +930,14 @@ def get_mime_type(metadata: dict, file_path: Path) -> str:
     return "application/octet-stream"
 
 
-def get_file(download_path: str | Path, file: str | Path) -> tuple[Path, int]:
+def get_file(download_path: str | Path, file: str | Path, exists: bool = True) -> tuple[Path, int]:
     """
     Get the real file path.
 
     Args:
         download_path (str|Path): Base download path.
         file (str|Path): File path.
+        exists (bool): Whether the file must already exist.
 
     Returns:
         Path: Real file path.
@@ -940,7 +949,7 @@ def get_file(download_path: str | Path, file: str | Path) -> tuple[Path, int]:
 
     try:
         realFile: Path = Path(calc_download_path(base_path=download_path, folder=str(file), create_path=False))
-        if realFile.exists():
+        if not exists or realFile.exists():
             return (realFile, 200)
     except Exception as e:
         LOG.exception(

--- a/app/routes/api/browser.py
+++ b/app/routes/api/browser.py
@@ -455,11 +455,22 @@ async def path_actions(request: Request, config: Config, queue: DownloadQueue, n
                 record(path, ok=False, error="New name is required for rename action.", action=action)
                 continue
 
-            new_path: Path = path.parent.joinpath(new_name)
+            if not isinstance(new_name, str) or Path(new_name).parts != (new_name,):
+                record(
+                    path,
+                    ok=False,
+                    error="New name must not contain path separators.",
+                    action=action,
+                    extra={"new_name": new_name},
+                )
+                continue
 
-            root_real: Path = Path(config.download_path).resolve()
-            resolved_new: Path = new_path.resolve(strict=False)
-            if resolved_new.parent != path.parent.resolve() or not resolved_new.is_relative_to(root_real):
+            new_path, status = get_file(
+                config.download_path,
+                path.parent.joinpath(new_name).relative_to(config.download_path),
+                exists=False,
+            )
+            if web.HTTPOk.status_code != status or new_path.parent != path.parent.resolve():
                 record(
                     path,
                     ok=False,

--- a/app/routes/api/browser.py
+++ b/app/routes/api/browser.py
@@ -456,6 +456,19 @@ async def path_actions(request: Request, config: Config, queue: DownloadQueue, n
                 continue
 
             new_path: Path = path.parent.joinpath(new_name)
+
+            root_real: Path = Path(config.download_path).resolve()
+            resolved_new: Path = new_path.resolve(strict=False)
+            if resolved_new.parent != path.parent.resolve() or not resolved_new.is_relative_to(root_real):
+                record(
+                    path,
+                    ok=False,
+                    error="New name must not contain path separators.",
+                    action=action,
+                    extra={"new_name": new_name},
+                )
+                continue
+
             if new_path.exists():
                 record(
                     new_path, ok=False, error="Destination already exists.", action=action, extra={"new_path": new_path}

--- a/app/routes/api/history.py
+++ b/app/routes/api/history.py
@@ -462,6 +462,19 @@ async def item_rename(
             params={"resource": "api.resources.file"},
         )
 
+    new_path = filepath.parent / new_name
+    try:
+        valid_parent = new_path.resolve(strict=False).parent == filepath.parent.resolve()
+    except (OSError, ValueError):
+        valid_parent = False
+    if Path(new_name).parts != (new_name,) or not valid_parent:
+        return api_error_response(
+            "New name must not contain path separators.",
+            code="INVALID",
+            status=web.HTTPBadRequest.status_code,
+            params={"field": "api.fields.name"},
+        )
+
     try:
         renamed, sidecar_renamed = rename_file(filepath, new_name)
     except ValueError as e:

--- a/app/tests/test_browser_routes.py
+++ b/app/tests/test_browser_routes.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from app.routes.api.browser import path_actions
+
+
+class _Request:
+    def __init__(self, payload: list[dict[str, str]]) -> None:
+        self.payload = payload
+
+    async def json(self) -> list[dict[str, str]]:
+        return self.payload
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "new_name",
+    [
+        "../outside.mp4",
+        "sub/file.mp4",
+        "sub/../file.mp4",
+        "/tmp/outside.mp4",
+        "file.mp4/",
+        "file\x00.mp4",
+        ".",
+        "..",
+    ],
+)
+async def test_rename_traversal(tmp_path: Path, new_name: str) -> None:
+    media = tmp_path / "video.mp4"
+    media.write_text("video")
+    request = _Request([{"action": "rename", "path": "video.mp4", "new_name": new_name}])
+    config = SimpleNamespace(download_path=str(tmp_path), browser_control_enabled=True)
+    queue = SimpleNamespace(done=SimpleNamespace(get_item=AsyncMock(return_value=None)))
+
+    response = await path_actions(request, config, queue, Mock())
+
+    assert response.status == 200
+    assert json.loads(response.body)[0]["status"] is False
+    assert media.exists()

--- a/app/tests/test_history_routes.py
+++ b/app/tests/test_history_routes.py
@@ -279,6 +279,27 @@ async def test_item_rename_conflict() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("new_name", ["../outside.mp4", "sub/file.mp4", "/tmp/outside.mp4", "video\x00.mp4"])
+async def test_item_rename_traversal(new_name: str) -> None:
+    with temporary_test_dir("history-rename-traversal") as temp_dir:
+        media = temp_dir / "video.mp4"
+        media.write_text("video")
+        request = _FakeRequest(payload={"new_name": new_name})
+        request.match_info["id"] = "item-1"
+        item = _make_download(filename="video.mp4", download_dir=str(temp_dir))
+        queue = SimpleNamespace(done=SimpleNamespace(get_by_id=AsyncMock(return_value=item), put=AsyncMock()))
+        notify = Mock()
+
+        response = await item_rename(request, queue, Encoder(), notify, SimpleNamespace(download_path=str(temp_dir)))
+
+        assert response.status == 400
+        assert json.loads(response.body)["code"] == "INVALID"
+        assert media.exists()
+        queue.done.put.assert_not_awaited()
+        notify.emit.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_item_thumbnail_sidecar() -> None:
     with temporary_test_dir("history-thumb-sidecar") as temp_dir:
         media = temp_dir / "video.mp4"

--- a/app/tests/test_utils.py
+++ b/app/tests/test_utils.py
@@ -1482,6 +1482,26 @@ class TestGetFile:
         assert isinstance(result_path, Path)
         assert status_code == 404
 
+    def test_get_file_leading_slash(self):
+        test_file = self.download_path / "test.txt"
+        test_file.write_text("content")
+
+        result_path, status_code = get_file(self.download_path, "/test.txt")
+
+        assert result_path == test_file
+        assert status_code == 200
+
+    def test_get_file_destination(self):
+        result_path, status_code = get_file(self.download_path, "new/test.txt", exists=False)
+
+        assert result_path == self.download_path / "new" / "test.txt"
+        assert status_code == 200
+
+    def test_get_file_destination_traversal(self):
+        _, status_code = get_file(self.download_path, "../outside.txt", exists=False)
+
+        assert status_code == 404
+
 
 class TestGet:
     """Test the get function for nested data access."""
@@ -2123,6 +2143,28 @@ class TestCreateCookiesFile:
 
 class TestRenameFile:
     """Test rename_file function."""
+
+    @pytest.mark.parametrize(
+        "new_name",
+        [
+            "../outside.mp4",
+            "sub/file.mp4",
+            "sub/../video.mp4",
+            "/tmp/outside.mp4",
+            "video.mp4/",
+            "video\x00.mp4",
+            ".",
+            "..",
+        ],
+    )
+    def test_traversal(self, tmp_path: Path, new_name: str):
+        test_file = tmp_path / "video.mp4"
+        test_file.write_text("test content")
+
+        with pytest.raises(ValueError, match="must not contain path separators"):
+            rename_file(test_file, new_name)
+
+        assert test_file.exists()
 
     def test_rename_single_file_no_sidecars(self, tmp_path: Path):
         """Test renaming a single file without sidecar files."""


### PR DESCRIPTION
### Summary

The file browser actions endpoint (`POST /api/file/actions`) validates the
destination for the `move` and `directory` actions against the download root
with `is_relative_to(root)`, but the `rename` action does not. The
user-supplied `new_name` is joined directly onto the item's parent directory
and passed to `rename_file()` without any traversal check.

```python
new_path: Path = path.parent.joinpath(new_name)
if new_path.exists():
    ...
renamed, sidecar_renamed = rename_file(path, new_name)
```

Because `new_name` is never restricted to a bare filename, a value containing
path separators (for example `../../../tmp/evil`) resolves outside the
download directory. `Path.rename()` then moves the item to that arbitrary
location on the same filesystem, escaping the download root that every other
file operation in this handler is careful to enforce.

### Impact

An operator of the file browser (which handles otherwise untrusted downloaded
files) can relocate any file under the download directory to an arbitrary
writable path outside of it. This is a directory-escape / arbitrary file
placement primitive that the surrounding code already tries to prevent for the
sibling `move` and `directory` actions.

### Fix

Mirror the existing validation used by the `move` and `directory` actions:
resolve the computed destination and reject it unless it stays within the
download root and in the same directory as the source (a rename should only
change the name, not relocate the file - that is what `move` is for).

```python
new_path: Path = path.parent.joinpath(new_name)

root_real: Path = Path(config.download_path).resolve()
resolved_new: Path = new_path.resolve(strict=False)
if resolved_new.parent != path.parent.resolve() or not resolved_new.is_relative_to(root_real):
    record(path, ok=False, error="New name must not contain path separators.", action=action, ...)
    continue
```

The change is limited to the `rename` branch and preserves the existing
behaviour for valid in-place renames.
