### PR TITLE
Refactor account modal form and clean up obsolete settings and tests

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -58,7 +58,6 @@ or the `environment:` section in `compose.yaml` file.
 | YTP_TEMP_DISABLED               | Disable temp files handling.                                        | `false`               |
 | YTP_RETRY                       | Number of additional attempts for retryable download failures.      | `0`                   |
 | YTP_RETRY_FRESH                 | Use a fresh download on the final retry attempt.                    | `false`               |
-| YTP_ALLOW_INTERNAL_URLS         | Allow requests to internal URLs                                     | `false`               |
 | YTP_SIMPLE_MODE                 | Switch default interface to Simple mode.                            | `false`               |
 | YTP_STATIC_UI_PATH              | Path to custom static UI files.                                     | `(not_set)`           |
 | YTP_AUTO_CLEAR_HISTORY_DAYS     | Number of days after which completed download history is cleared.   | `0`                   |
@@ -70,7 +69,6 @@ or the `environment:` section in `compose.yaml` file.
 | YTP_THUMB_CONCURRENCY           | The number of concurrent ffmpeg thumbnail generations allowed.      | `2`                   |
 | YTP_THUMB_GENERATE              | Enable ffmpeg thumbnail generation when no local thumbnail exists.  | `true`                |
 | YTP_THUMB_SIDECAR               | Save generated thumbnails next to media instead of temp cache.      | `false`               |
-| YTP_DISABLE_EXEC                | Strip some dangerous yt-dlp options.                                | `false`               |
 
 > [!NOTE]
 > To raise the worker limit for a specific extractor, set an env variable using this format: `YTP_MAX_WORKERS_FOR_<EXTRACTOR_NAME>`
@@ -181,9 +179,6 @@ inside the container.
 1. **Enable authentication**.
 2. **Put it behind a reverse proxy** with its own authentication layer (see [Run behind reverse proxy](#run-behind-reverse-proxy)).
 3. **Keep it on a private network** with no public exposure.
-
-> [!NOTE]
-> `YTP_DISABLE_EXEC=true` blocks some command-execution options. It does not restrict access to the rest of the API.
 
 # I cant download anything
 
@@ -583,13 +578,6 @@ For more information about the supported codecs, please refer to the [SegmentEnc
 
 If GPU encoding fails and software encoding is used, you will have to restart the container to try GPU encoding again. 
 as we only test for GPU encoding once on first video stream.
-
-# Allowing internal URLs requests
-
-By default, YTPTube prevents requests to internal resources. However, if you want to allow requests to internal URLs, you can set the `YTP_ALLOW_INTERNAL_URLS` environment variable to `true`. This will allow requests to internal URLs. 
-
-We do not recommend enabling this option unless you know what you are doing, as it can expose your internal network to 
-potential security risks. This should only be used if it's truly needed.
 
 # How to setup CI on Gitea?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,39 +2,43 @@
 
 ## Reporting a vulnerability
 
-Report security issues through [GitHub private vulnerability reporting](https://github.com/arabcoders/ytptube/security/advisories/new) (`Security` > `Report a vulnerability`). Do not open a public issue.
+Report security issues via [GitHub](https://github.com/arabcoders/ytptube/security/advisories/new). Do not open a public issue.
 
-Expect an initial response within a few days. Include:
+Expect reply within a few days at most usually in hours. Include:
 
-- A working reproduction
-- The YTPTube release version shown in the UI footer
 - The security impact
+- A working re-production. `PoC` code is preferred, but a detailed description of the steps to reproduce is acceptable.
+- The YTPTube release version shown in the UI footer
 - Relevant configuration with secrets removed
+
+Security issues in yt-dlp itself, including vulnerabilities in its extractors, option parsing, or command execution,
+should be reported to the [yt-dlp project](https://github.com/yt-dlp/yt-dlp/security/advisories/new), not to YTPTube.
+
+Report issues to YTPTube when the vulnerability is caused by its integration or exposes functionality without the
+required authentication boundary.
 
 ## Supported versions
 
-Only the latest release is supported. Update to the current Docker image or latest native release before reporting. 
+Only the latest release is supported. Update to the current Docker image or latest native release before reporting.
 Reports that cannot be reproduced on the latest release will be closed.
 
 ## Reports we close
 
-YTPTube is an administrative application, not a sandbox for untrusted users. Anyone with valid application credentials 
-is trusted to manage downloads, tasks, files, and yt-dlp options.
+YTPTube is an administrative application, not a sandbox for untrusted users. Anyone with valid application credentials
+is trusted to manage the entire YTPTube instance and what it has access to.
 
 Reports that only describe the following behavior will be closed:
 
-- Unauthenticated access when `YTP_DISABLE_AUTH=true`, including the default configuration in native builds. This setting 
-disables application authentication and is intended for deployments protected by a trusted reverse proxy or private network.
-- First-user registration through `/setup` while no account exists. This is the intended bootstrap flow; reports must 
-demonstrate access after setup is complete or another authentication boundary bypass.
-- Command execution through yt-dlp options such as `--exec` by an authenticated user when `YTP_DISABLE_EXEC=false`.
-- Path traversal or output path control through yt-dlp output templates by an authenticated user. Output templates are 
-passed to yt-dlp and are not a path sandbox.
-- Internal network requests made by an authenticated administrator.
+- Unauthenticated access when `YTP_DISABLE_AUTH=true`, including the default configuration in native builds. This setting
+  disables application authentication and is intended for deployments protected by a trusted reverse proxy or private network.
+- First-user registration through `/setup` while no account exists. This is the intended bootstrap flow; reports must
+  demonstrate access after setup is complete or another authentication boundary bypass.
+- Behavior caused by yt-dlp itself, including command execution or path control through options such as `--exec`, `--output`,
+  or `--netrc`. yt-dlp is not sandboxed and can execute arbitrary commands.
+- YTPTube does not sandbox outbound network access. Authenticated administrators can cause requests to internal services,
+including through redirects or yt-dlp behavior or even via dns rebinding.
 
-`YTP_DISABLE_EXEC=true` blocks some command-execution options. It does not turn yt-dlp into a sandbox.
-
-A report about these areas must demonstrate a boundary bypass, such as access without valid authentication while auth is 
+A report about these areas must demonstrate a boundary bypass, such as access without valid authentication while auth is
 enabled.
 
 ## Generated reports

--- a/app/features/conditions/router.py
+++ b/app/features/conditions/router.py
@@ -1,4 +1,3 @@
-import asyncio
 from collections import OrderedDict
 from typing import Any
 
@@ -97,7 +96,7 @@ async def conditions_test(request: Request, encoder: Encoder, cache: Cache, conf
         )
 
     try:
-        await asyncio.to_thread(validate_url, url, config.allow_internal_urls)
+        validate_url(url)
     except ValueError as e:
         return api_error_response(
             str(e),

--- a/app/features/conditions/tests/test_conditions.py
+++ b/app/features/conditions/tests/test_conditions.py
@@ -4,14 +4,9 @@ from __future__ import annotations
 
 import pytest
 import pytest_asyncio
-from types import SimpleNamespace
-
-from app.features.conditions.router import conditions_test
-from app.library.config import Config
-from app.library.encoder import Encoder
 from app.features.conditions.repository import ConditionsRepository
 from app.library.sqlite_store import SqliteStore
-from app.tests.helpers import make_in_memory_db_path, url_for
+from app.tests.helpers import make_in_memory_db_path
 
 
 @pytest_asyncio.fixture
@@ -33,30 +28,6 @@ async def repo():
     # Reset singletons
     ConditionsRepository._reset_singleton()
     SqliteStore._reset_singleton()
-
-
-class TestAllowInternalUrlsScope:
-    def setup_method(self) -> None:
-        Config._reset_singleton()
-
-    @pytest.mark.asyncio
-    async def test_rejects_internal_url(self, test_client) -> None:
-        config = Config.get_instance()
-        config.allow_internal_urls = False
-        encoder = Encoder()
-        cache = SimpleNamespace(hash=lambda value: value, has=lambda _key: False, set=lambda **_kwargs: None)
-
-        async def handler(request):
-            return await conditions_test(request, encoder, cache, config)
-
-        client = await test_client({"condition_test": handler})
-        response = await client.post(
-            url_for("condition_test"),
-            json={"url": "http://127.0.0.1/test", "condition": "title", "preset": config.default_preset},
-        )
-
-        assert response.status == 400
-        assert "internal urls" in (await response.text()).lower()
 
 
 class TestConditionsRepository:

--- a/app/features/streaming/tests/test_ffprobe.py
+++ b/app/features/streaming/tests/test_ffprobe.py
@@ -27,26 +27,6 @@ class TestFFProbe:
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     @pytest.mark.asyncio
-    async def test_ffprobe_with_existing_file(self):
-        """Test ffprobe with an existing file."""
-        from app.features.streaming.library.ffprobe import FFProbeResult, ffprobe
-
-        # Mock subprocess to avoid actual ffprobe execution
-        with patch("asyncio.create_subprocess_exec") as mock_subprocess:
-            # Mock the subprocess result
-            mock_process = AsyncMock()
-            mock_process.wait.return_value = 0
-            mock_process.communicate.return_value = (b'{"format": {"duration": "10.0"}}', b"")
-            mock_subprocess.return_value = mock_process
-
-            with patch("anyio.open_file") as mock_open_file:
-                mock_file = AsyncMock()
-                mock_open_file.return_value.__aenter__.return_value = mock_file
-
-                result = await ffprobe(str(self.test_file))
-                assert isinstance(result, FFProbeResult)
-
-    @pytest.mark.asyncio
     async def test_ffprobe_with_nonexistent_file(self):
         """Test ffprobe with a non-existent file."""
         from app.features.streaming.library.ffprobe import ffprobe

--- a/app/features/tasks/definitions/handlers/generic.py
+++ b/app/features/tasks/definitions/handlers/generic.py
@@ -143,7 +143,7 @@ class GenericTaskHandler(BaseHandler):
 
     @staticmethod
     async def extract(task: HandleTask, config: Config | None = None) -> TaskResult | TaskFailure:
-        config = config or Config.get_instance()
+        _ = config
         definition: TaskDefinition | None = await GenericTaskHandler._find_definition(task.url)
         if not definition:
             return TaskFailure(message="No generic task definition matched the provided URL.")
@@ -152,7 +152,7 @@ class GenericTaskHandler(BaseHandler):
         target_url: str = definition.definition.request.url or task.url
 
         try:
-            await asyncio.to_thread(validate_url, target_url, config.allow_internal_urls)
+            validate_url(target_url)
         except ValueError as exc:
             return TaskFailure(message="Invalid target URL.", error=str(exc))
 

--- a/app/features/tasks/definitions/tests/test_generic_task_handler.py
+++ b/app/features/tasks/definitions/tests/test_generic_task_handler.py
@@ -360,7 +360,6 @@ async def test_generic_task_handler_inspect(monkeypatch):
 
     monkeypatch.setattr(GenericTaskHandler, "_fetch_content", staticmethod(fake_fetch_content))
     config = Config.get_instance()
-    monkeypatch.setattr(config, "allow_internal_urls", True)
 
     # Mock fetch_info to return valid info with required fields for archive ID generation
     async def fake_fetch_info(config, url, **kwargs):  # noqa: ARG001
@@ -377,40 +376,6 @@ async def test_generic_task_handler_inspect(monkeypatch):
         assert item.title == "First"
         assert item.thumbnail == "https://example.com/first.jpg"
         assert item.description == "First description"
-
-
-@pytest.mark.asyncio
-async def test_extract_internal(monkeypatch):
-    definition = TaskDefinition(
-        id=8,
-        name="internal",
-        priority=0,
-        match_url=["https://example.com/*"],
-        definition=Definition(
-            parse=Parse.model_validate({"link": {"type": "jsonpath", "expression": "url"}}),
-            request=RequestConfig(url="http://127.0.0.1/private"),
-            response=ResponseConfig(type="json"),
-        ),
-    )
-
-    async def fake_find_definition(cls, url):  # noqa: ARG001
-        return definition
-
-    async def fake_fetch_content(*args, **kwargs):  # noqa: ARG001
-        pytest.fail("Internal URL was fetched")
-
-    monkeypatch.setattr(GenericTaskHandler, "_find_definition", classmethod(fake_find_definition))
-    monkeypatch.setattr(GenericTaskHandler, "_fetch_content", staticmethod(fake_fetch_content))
-    config = Config.get_instance()
-    monkeypatch.setattr(config, "allow_internal_urls", False)
-
-    result = await GenericTaskHandler.extract(
-        HandleTask(id=1, name="Internal", url="https://example.com/source"),
-        config=config,
-    )
-
-    assert isinstance(result, TaskFailure)
-    assert result.message == "Invalid target URL."
 
 
 def test_parse_items_json_list():

--- a/app/features/tasks/definitions/tests/test_generic_task_handler.py
+++ b/app/features/tasks/definitions/tests/test_generic_task_handler.py
@@ -24,97 +24,9 @@ def reset_generic_handler(monkeypatch):
     monkeypatch.setattr(GenericTaskHandler, "_sources_mtime", {})
 
 
-def test_build_def_payload():
-    definition = TaskDefinition(
-        id=1,
-        name="example",
-        priority=0,
-        match_url=["https://example.com/articles/*"],
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-        definition=Definition(
-            parse=Parse.model_validate(
-                {
-                    "link": {"type": "css", "expression": ".article a.link::attr(href)"},
-                    "title": {"type": "css", "expression": ".article .title", "attribute": "text"},
-                }
-            ),
-            engine=EngineConfig(),
-            request=RequestConfig(),
-            response=ResponseConfig(),
-        ),
-    )
-
-    assert definition.name == "example"
-    assert definition.match_url == ["https://example.com/articles/*"]
-    assert definition.definition.parse["link"]["expression"] == ".article a.link::attr(href)"
-
-
 def test_request_method():
     with pytest.raises(ValidationError):
         RequestConfig.model_validate({"method": "DELETE"})
-
-
-def test_build_def_container():
-    definition = TaskDefinition(
-        id=2,
-        name="container",
-        priority=0,
-        match_url=["https://example.com/cards"],
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-        definition=Definition(
-            parse=Parse.model_validate(
-                {
-                    "items": {
-                        "selector": ".cards .card",
-                        "fields": {
-                            "link": {"type": "css", "expression": ".card-header a", "attribute": "href"},
-                            "title": {"type": "css", "expression": ".card-header a", "attribute": "text"},
-                        },
-                    }
-                }
-            ),
-            engine=EngineConfig(),
-            request=RequestConfig(),
-            response=ResponseConfig(),
-        ),
-    )
-
-    assert definition.definition.parse["items"]["selector"] == ".cards .card"
-    assert definition.definition.parse["items"]["fields"]["link"]["attribute"] == "href"
-
-
-def test_build_def_json():
-    definition = TaskDefinition(
-        id=3,
-        name="json-def",
-        priority=0,
-        match_url=["https://example.com/api"],
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-        definition=Definition(
-            parse=Parse.model_validate(
-                {
-                    "items": {
-                        "type": "jsonpath",
-                        "selector": "items",
-                        "fields": {
-                            "link": {"type": "jsonpath", "expression": "url"},
-                            "title": {"type": "jsonpath", "expression": "title"},
-                        },
-                    }
-                }
-            ),
-            engine=EngineConfig(),
-            request=RequestConfig(),
-            response=ResponseConfig(type="json"),
-        ),
-    )
-
-    assert definition.definition.response.type == "json"
-    assert definition.definition.parse["items"]["type"] == "jsonpath"
-    assert definition.definition.parse["items"]["fields"]["link"]["type"] == "jsonpath"
 
 
 def test_parse_items_basic():

--- a/app/features/tasks/definitions/tests/test_rss_handler.py
+++ b/app/features/tasks/definitions/tests/test_rss_handler.py
@@ -32,21 +32,11 @@ class TestRssHandlerParsing:
 
     @pytest.mark.parametrize(("url", "expected"), RssGenericHandler.tests())
     def test_url_parsing(self, url: str, expected: bool):
-        """Test URL parsing against all defined test cases."""
         result = RssGenericHandler.parse(url)
-        is_matched = result is not None
-        assert is_matched == expected, f"URL '{url}' expected {expected}, got {is_matched}"
-
-    @pytest.mark.parametrize(("url", "expected"), RssGenericHandler.tests())
-    def test_returns_url_dict_match(self, url: str, expected: bool):
-        """Test that parse returns dict with 'url' key for valid feeds."""
-        result = RssGenericHandler.parse(url)
+        assert (result is not None) == expected
         if expected:
             assert result is not None
-            assert "url" in result
             assert result["url"] == url
-        else:
-            assert result is None
 
 
 class TestRssHandlerExtraction:

--- a/app/features/tasks/definitions/tests/test_task_definitions.py
+++ b/app/features/tasks/definitions/tests/test_task_definitions.py
@@ -81,9 +81,6 @@ class TestTaskDefinitionsRepository:
         with pytest.raises(ValueError, match="already exists"):
             await repo.create(payload)
 
-        with pytest.raises(ValueError, match="already exists"):
-            await repo.create(payload)
-
     @pytest.mark.asyncio
     async def test_update_missing_raises(self, repo: TaskDefinitionsRepository) -> None:
         with pytest.raises(KeyError, match="not found"):

--- a/app/features/tasks/router.py
+++ b/app/features/tasks/router.py
@@ -1,4 +1,3 @@
-import asyncio
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import web
@@ -532,7 +531,7 @@ async def tasks_update(
 
 
 @route("POST", "api/tasks/inspect", "task_handler_inspect")
-async def task_handler_inspect(request: Request, handler: TaskHandle, encoder: Encoder, config: Config) -> Response:
+async def task_handler_inspect(request: Request, handler: TaskHandle, encoder: Encoder) -> Response:
     """
     Check if handler can process the given URL.
 
@@ -540,7 +539,6 @@ async def task_handler_inspect(request: Request, handler: TaskHandle, encoder: E
         request: The request object.
         handler: The handler service instance.
         encoder: The encoder instance.
-        config: The config instance.
 
     Returns:
         The response object.
@@ -560,7 +558,7 @@ async def task_handler_inspect(request: Request, handler: TaskHandle, encoder: E
     static_only: bool = data.get("static_only", False) if isinstance(data, dict) else False
     if not static_only:
         try:
-            await asyncio.to_thread(validate_url, url, config.allow_internal_urls)
+            validate_url(url)
         except ValueError as e:
             return api_error_response(
                 str(e),
@@ -896,7 +894,7 @@ async def task_metadata(request: Request, repo: TasksRepository, config: Config,
                         continue
 
                     try:
-                        await asyncio.to_thread(validate_url, url, config.allow_internal_urls)
+                        validate_url(url)
                     except ValueError as exc:
                         LOG.warning(
                             "Task '%s' has an invalid '%s' thumbnail URL because %s.",

--- a/app/features/tasks/schemas.py
+++ b/app/features/tasks/schemas.py
@@ -51,7 +51,7 @@ class Task(BaseModel):
         from app.library.Utils import validate_url
 
         try:
-            validate_url(value, allow_internal=True)
+            validate_url(value)
         except ValueError as e:
             msg = f"Invalid URL format: {e!s}"
             raise ValueError(msg) from e

--- a/app/features/ytdlp/router.py
+++ b/app/features/ytdlp/router.py
@@ -1,4 +1,3 @@
-import asyncio
 import copy
 import json
 import logging
@@ -439,7 +438,7 @@ async def get_info(request: Request, cache: Cache, config: Config) -> Response:
         )
 
     try:
-        await asyncio.to_thread(validate_url, url, config.allow_internal_urls)
+        validate_url(url)
     except ValueError as e:
         return api_error_response(
             str(e),
@@ -613,7 +612,7 @@ async def get_options() -> Response:
 
 
 @route("POST", "api/yt-dlp/archive_id/", "get_archive_ids")
-async def get_archive_ids(request: Request, config: Config) -> Response:
+async def get_archive_ids(request: Request) -> Response:
     """
     Get the archive IDs for the given URLs.
 
@@ -638,7 +637,7 @@ async def get_archive_ids(request: Request, config: Config) -> Response:
             response.append(dct)
             continue
         try:
-            await asyncio.to_thread(validate_url, url, config.allow_internal_urls)
+            validate_url(url)
             dct.update(get_archive_id(url))
         except ValueError as e:
             dct.update({"id": None, "ie_key": None, "archive_id": None, "error": str(e)})

--- a/app/features/ytdlp/tests/test_ytdlp_extractor.py
+++ b/app/features/ytdlp/tests/test_ytdlp_extractor.py
@@ -102,20 +102,6 @@ class TestExtractInfo:
         mock_ytdlp.extract_info.assert_called_once()
 
     @patch("app.features.ytdlp.extractor.YTDLP")
-    def test_extract_info_with_debug(self, mock_ytdlp_class):
-        """Test extract_info with debug enabled."""
-        mock_ytdlp = MagicMock()
-        mock_ytdlp.extract_info.return_value = {"title": "Test Video"}
-        mock_ytdlp_class.return_value = mock_ytdlp
-
-        config = {}
-        url = "https://example.com/video"
-
-        (result, logs) = extract_info_sync(config, url, debug=True)
-        assert isinstance(result, dict), "Result should be a dictionary"
-        assert isinstance(logs, list), "Logs should be a list"
-
-    @patch("app.features.ytdlp.extractor.YTDLP")
     def test_info_mirrors_debug_console(self, mock_ytdlp_class):
         seen: list[tuple[int, str]] = []
 

--- a/app/features/ytdlp/tests/test_ytdlp_module.py
+++ b/app/features/ytdlp/tests/test_ytdlp_module.py
@@ -1,11 +1,8 @@
-import importlib
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from yt_dlp.globals import extractors as ytdlp_extractors
-
 from app.features.ytdlp.outtmpl import rewrite_outtmpl
 from app.features.ytdlp.patches import patch_windows_popen_wait
 from app.features.ytdlp.utils import _DATA
@@ -159,20 +156,6 @@ class TestYTDLP:
         mock_super_init.assert_called_once_with(params=None, auto_init=True)
         assert isinstance(ytdlp.archive, _ArchiveProxy)
         assert not ytdlp.archive
-
-    @patch("app.features.ytdlp.ytdlp.yt_dlp.YoutubeDL.__init__")
-    def test_init_patches_wait(self, mock_super_init) -> None:
-        mock_super_init.return_value = None
-
-        class FakePopen:
-            def wait(self, timeout=None):
-                return timeout
-
-        with patch("app.features.ytdlp.patches.sys.platform", "win32"):
-            with patch("yt_dlp.utils.Popen", FakePopen):
-                YTDLP(params={})
-
-        assert getattr(FakePopen, "_ytptube_wait_patched", False) is True
 
     def test_wait_patch_polls(self) -> None:
         calls: list[float | None] = []
@@ -350,14 +333,6 @@ class TestYTDLP:
 
         assert len(result) == 8
         assert result.isalnum()
-
-    def test_exec_init(self) -> None:
-        YTDLP(
-            params={
-                "compat_opts": set(),
-                "postprocessors": [{"key": "Exec", "exec_cmd": "echo %(title)q"}],
-            }
-        )
 
     def test_outtmpl_reuses_value(self) -> None:
         ytdlp = YTDLP(params={"outtmpl": {"default": "%(title)s"}})

--- a/app/features/ytdlp/tests/test_ytdlp_opts.py
+++ b/app/features/ytdlp/tests/test_ytdlp_opts.py
@@ -12,31 +12,6 @@ from app.features.ytdlp.ytdlp_opts import YTDLPOpts
 class TestYTDLPOpts:
     """Test the YTDLPOpts class."""
 
-    def test_constructor_initializes_correctly(self):
-        """Test that YTDLPOpts constructor initializes all attributes."""
-        with patch("app.features.ytdlp.ytdlp_opts.Config") as mock_config:
-            mock_config_instance = Mock()
-            mock_config.get_instance.return_value = mock_config_instance
-
-            opts = YTDLPOpts()
-
-            assert opts._config is mock_config_instance
-            assert opts._item_opts == {}
-            assert opts._preset_opts == {}
-            assert opts._item_cli == []
-            assert opts._preset_cli == ""
-
-    def test_get_instance(self):
-        """Test that get_instance returns a reset YTDLPOpts instance."""
-        with patch("app.features.ytdlp.ytdlp_opts.Config"):
-            opts = YTDLPOpts.get_instance()
-
-            assert isinstance(opts, YTDLPOpts)
-            assert opts._item_opts == {}
-            assert opts._preset_opts == {}
-            assert opts._item_cli == []
-            assert opts._preset_cli == ""
-
     def test_add_cli_valid_args(self):
         """Test adding valid CLI arguments."""
         with (
@@ -403,24 +378,6 @@ class TestYTDLPOpts:
             assert opts._item_cli == []
             assert opts._preset_cli == ""
 
-    def test_method_chaining(self):
-        """Test that methods support chaining."""
-        with (
-            patch("app.features.ytdlp.ytdlp_opts.Config"),
-            patch("app.features.ytdlp.ytdlp_opts.arg_converter"),
-            patch("app.features.presets.service.Presets") as mock_presets,
-        ):
-            mock_presets_instance = Mock()
-            mock_presets_instance.get.return_value = None
-            mock_presets.get_instance.return_value = mock_presets_instance
-
-            opts = YTDLPOpts()
-
-            # Test chaining
-            result = opts.add_cli("--format best").add({"quality": "720p"}).preset("nonexistent").reset()
-
-            assert result is opts
-
     def test_debug_logging(self):
         """Test debug logging when enabled."""
         with (
@@ -515,14 +472,6 @@ class TestYTDLPOpts:
 
 class TestARGSMerger:
     """Test the ARGSMerger class."""
-
-    def test_constructor_initializes_empty_args(self):
-        """Test that ARGSMerger constructor initializes with empty args list."""
-        from app.features.ytdlp.ytdlp_opts import ARGSMerger
-
-        merger = ARGSMerger()
-
-        assert merger.args == []
 
     def test_add_valid_args(self):
         """Test adding valid command-line arguments."""
@@ -711,15 +660,6 @@ class TestARGSMerger:
 
             assert result == {"format": "best"}
             mock_converter.assert_called_once_with(args="--format best", level=False)
-
-    def test_get_instance(self):
-        """Test get_instance static method."""
-        from app.features.ytdlp.ytdlp_opts import ARGSMerger
-
-        merger = ARGSMerger.get_instance()
-
-        assert isinstance(merger, ARGSMerger)
-        assert merger.args == []
 
     def test_reset(self):
         """Test reset method clears args."""

--- a/app/features/ytdlp/tests/test_ytdlp_router.py
+++ b/app/features/ytdlp/tests/test_ytdlp_router.py
@@ -60,7 +60,7 @@ async def test_info_preserves_entries(monkeypatch: pytest.MonkeyPatch, test_clie
     }
     fetch = AsyncMock(return_value=(info, []))
     cache = _Cache()
-    config = SimpleNamespace(default_preset="default", allow_internal_urls=False)
+    config = SimpleNamespace(default_preset="default")
 
     monkeypatch.setattr(router, "validate_url", lambda *_args: True)
     monkeypatch.setattr(router.Presets, "get_instance", lambda: _Presets())
@@ -94,7 +94,7 @@ async def test_info_refreshes_archive(monkeypatch: pytest.MonkeyPatch, test_clie
         "_cached": {"ttl": 300, "expires": 9999999999},
     }
     cache = _Cache(cached)
-    config = SimpleNamespace(default_preset="default", allow_internal_urls=False)
+    config = SimpleNamespace(default_preset="default")
 
     monkeypatch.setattr(router, "validate_url", lambda *_args: True)
     monkeypatch.setattr(router.Presets, "get_instance", lambda: _Presets())
@@ -122,7 +122,7 @@ async def test_info_caps_browser_wait(
     test_client,
 ) -> None:
     fetch = AsyncMock(return_value=({"title": "Playlist", "entries": []}, []))
-    config = SimpleNamespace(default_preset="default", allow_internal_urls=False)
+    config = SimpleNamespace(default_preset="default")
 
     monkeypatch.setattr(router, "validate_url", lambda *_args: True)
     monkeypatch.setattr(router.Presets, "get_instance", lambda: _Presets())

--- a/app/features/ytdlp/tests/test_ytdlp_utils.py
+++ b/app/features/ytdlp/tests/test_ytdlp_utils.py
@@ -2,14 +2,13 @@ import logging
 from pathlib import Path
 import re
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from app.features.ytdlp.utils import (
     LogWrapper,
     extract_ytdlp_logs,
-    get_archive_id,
     ytdlp_reject,
     parse_outtmpl,
     get_extras,
@@ -489,16 +488,6 @@ class TestGetStaticYtdlp:
 
         _DATA.YTDLP_INFO_CLS = None
 
-    def test_instance(self):
-        """Test that get_static_ytdlp returns a YTDLP instance."""
-        from app.features.ytdlp.ytdlp import YTDLP
-
-        # Get the cached instance
-        instance = get_ytdlp()
-
-        assert instance is not None
-        assert isinstance(instance, YTDLP)
-
     def test_get_static_ytdlp_same(self):
         """Test that get_static_ytdlp returns the same cached instance."""
 
@@ -530,26 +519,6 @@ class TestGetStaticYtdlp:
         assert params.get("ignoreerrors") is True
         assert params.get("ignore_no_formats_error") is True
         assert params.get("quiet") is True
-
-
-class TestGetArchiveId:
-    """Test the get_archive_id function."""
-
-    @patch("app.features.ytdlp.utils._DATA.YTDLP_INFO_CLS")
-    def test_get_archive_id_basic(self, mock_ytdlp):
-        """Test basic archive ID extraction."""
-        mock_ytdlp._ies = {}
-
-        result = get_archive_id("https://youtube.com/watch?v=test123")
-        assert isinstance(result, dict)
-        assert "id" in result
-        assert "ie_key" in result
-        assert "archive_id" in result
-
-    def test_archive_id_invalid_url(self):
-        """Test with invalid URL."""
-        result = get_archive_id("invalid-url")
-        assert isinstance(result, dict)
 
 
 class TestArchiveFunctions:

--- a/app/features/ytdlp/ytdlp_opts.py
+++ b/app/features/ytdlp/ytdlp_opts.py
@@ -397,30 +397,6 @@ class YTDLPOpts:
 
         data: dict = merge_dict(user_cli, merge_dict(self._item_opts, merge_dict(self._preset_opts, default_opts)))
 
-        if self._config.disable_exec:
-            stripped: list[str] = []
-            if data.pop("netrc_cmd", None):
-                stripped.append("netrc_cmd")
-
-            if "postprocessors" in data:
-                exec_pps = [
-                    pp for pp in data["postprocessors"] if isinstance(pp, dict) and pp.get("key", "").startswith("Exec")
-                ]
-                if exec_pps:
-                    stripped.extend(pp.get("key") for pp in exec_pps)
-                    data["postprocessors"] = [
-                        pp
-                        for pp in data["postprocessors"]
-                        if not (isinstance(pp, dict) and pp.get("key", "").startswith("Exec"))
-                    ]
-
-            if stripped:
-                LOG.warning(
-                    "Stripped %d dangerous options from yt-dlp options.",
-                    len(stripped),
-                    extra={"stripped": stripped, "reason": "YTP_DISABLE_EXEC is enabled"},
-                )
-
         if not keep:
             self.reset()
 

--- a/app/library/Utils.py
+++ b/app/library/Utils.py
@@ -1,12 +1,10 @@
 import base64
 import copy
 import glob
-import ipaddress
 import json
 import logging
 import os
 import re
-import socket
 import time
 import traceback
 import uuid
@@ -529,26 +527,18 @@ def check_id(file: Path) -> bool | Path:
     return False
 
 
-@timed_lru_cache(ttl_seconds=300, max_size=256)
-def is_private_address(hostname: str) -> bool:
-    ip: str = socket.gethostbyname(hostname)
-    ip_obj: ipaddress.IPv4Address | ipaddress.IPv6Address = ipaddress.ip_address(ip)
-    return ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_reserved or ip_obj.is_link_local
-
-
-def validate_url(url: str, allow_internal: bool = False) -> bool:
+def validate_url(url: str) -> bool:
     """
-    Validate if the url is valid and allowed.
+    Validate the URL format.
 
     Args:
         url (str): URL to validate.
-        allow_internal (bool): If True, allow internal URLs or private networks.
 
     Returns:
-        bool: True if the URL is valid and allowed.
+        bool: True if the URL is valid.
 
     Raises:
-        ValueError: If the URL is invalid or not allowed.
+        ValueError: If the URL is invalid.
 
     """
     if not url:
@@ -572,20 +562,6 @@ def validate_url(url: str, allow_internal: bool = False) -> bool:
     if not hostname:
         msg = "Invalid hostname."
         raise ValueError(msg)
-
-    if allow_internal is False:
-        try:
-            if is_private_address(hostname):
-                msg = "Access to internal urls or private networks is not allowed."
-                raise ValueError(msg)
-        except socket.gaierror as e:
-            LOG.exception(
-                "Failed to resolve hostname '%s'.",
-                hostname,
-                extra={"hostname": hostname, "exception_type": type(e).__name__},
-            )
-            msg = "Invalid hostname."
-            raise ValueError(msg) from e
 
     return True
 

--- a/app/library/config.py
+++ b/app/library/config.py
@@ -69,9 +69,6 @@ class Config(metaclass=Singleton):
     temp_disabled: bool = False
     """Disable the temporary files feature."""
 
-    allow_internal_urls: bool = False
-    """Allow requests to internal URLs."""
-
     output_template: str = "%(title)s.%(ext)s"
     """The output template to use for the downloaded files."""
 
@@ -119,9 +116,6 @@ class Config(metaclass=Singleton):
 
     cors_origins: str = "*"
     """Allowed CORS origins."""
-
-    disable_exec: bool = False
-    """Strip some dangerous yt-dlp options."""
 
     remove_files: bool = False
     """Remove downloaded files when removing the record."""
@@ -338,13 +332,11 @@ class Config(metaclass=Singleton):
         "prevent_live_premiere",
         "temp_disabled",
         "retry_fresh",
-        "allow_internal_urls",
         "simple_mode",
         "ignore_archived_items",
         "check_for_updates",
         "thumb_generate",
         "thumb_sidecar",
-        "disable_exec",
         "disable_auth",
         "extract_info_keep_alive",
         "monitor_enabled",

--- a/app/tests/test_ag_utils.py
+++ b/app/tests/test_ag_utils.py
@@ -31,19 +31,6 @@ class TestGetValue:
         assert result == "called"
         mock_func.assert_called_once()
 
-    def test_get_value_with_lambda(self):
-        """Test get_value with lambda functions."""
-        assert get_value(lambda: 100) == 100
-        assert get_value(lambda: "lambda_result") == "lambda_result"
-
-    def test_get_value_with_function(self):
-        """Test get_value with regular functions."""
-
-        def test_func():
-            return "function_result"
-
-        assert get_value(test_func) == "function_result"
-
 
 class TestAgSet:
     """Test the ag_set function."""

--- a/app/tests/test_async_url_validation_routes.py
+++ b/app/tests/test_async_url_validation_routes.py
@@ -18,44 +18,37 @@ def reset_config() -> Generator[None, None, None]:
     Config._reset_singleton()
 
 
-def _patch_thread(monkeypatch: pytest.MonkeyPatch, module: Any, config: Config, url: str) -> dict[str, bool]:
-    seen = {"to_thread": False, "validate": False}
+def _reject_url(monkeypatch: pytest.MonkeyPatch, module: Any, url: str) -> dict[str, bool]:
+    seen = {"validate": False}
 
-    def fake_validate_url(next_url: str, allow_internal: bool = False) -> bool:
+    def reject(next_url: str) -> bool:
         seen["validate"] = True
         assert next_url == url
-        assert allow_internal is config.allow_internal_urls
         raise ValueError("Invalid hostname.")
 
-    async def fake_to_thread(func, *args, **kwargs):
-        seen["to_thread"] = True
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(module, "validate_url", fake_validate_url)
-    monkeypatch.setattr(module.asyncio, "to_thread", fake_to_thread)
+    monkeypatch.setattr(module, "validate_url", reject)
     return seen
 
 
 @pytest.mark.asyncio
-async def test_inspect_thread(monkeypatch: pytest.MonkeyPatch, test_client) -> None:
-    config = Config.get_instance()
-    seen = _patch_thread(monkeypatch, tasks_router, config, "https://bad.example/task")
+async def test_inspect_validation(monkeypatch: pytest.MonkeyPatch, test_client) -> None:
+    seen = _reject_url(monkeypatch, tasks_router, "https://bad.example/task")
 
     async def handler(request):
-        return await tasks_router.task_handler_inspect(request, handler=None, encoder=None, config=config)
+        return await tasks_router.task_handler_inspect(request, handler=None, encoder=None)
 
     client = await test_client({"task_handler_inspect": handler})
     response = await client.post(url_for("task_handler_inspect"), json={"url": "https://bad.example/task"})
 
     assert response.status == 400
     assert (await response.json())["error"] == "Invalid hostname."
-    assert seen == {"to_thread": True, "validate": True}
+    assert seen == {"validate": True}
 
 
 @pytest.mark.asyncio
-async def test_conditions_thread(monkeypatch: pytest.MonkeyPatch, test_client) -> None:
+async def test_conditions_validation(monkeypatch: pytest.MonkeyPatch, test_client) -> None:
     config = Config.get_instance()
-    seen = _patch_thread(monkeypatch, conditions_router, config, "https://bad.example/cond")
+    seen = _reject_url(monkeypatch, conditions_router, "https://bad.example/cond")
 
     async def handler(request):
         return await conditions_router.conditions_test(request, encoder=None, cache=None, config=config)
@@ -67,13 +60,13 @@ async def test_conditions_thread(monkeypatch: pytest.MonkeyPatch, test_client) -
 
     assert response.status == 400
     assert (await response.json())["error"] == "Invalid hostname."
-    assert seen == {"to_thread": True, "validate": True}
+    assert seen == {"validate": True}
 
 
 @pytest.mark.asyncio
-async def test_info_thread(monkeypatch: pytest.MonkeyPatch, test_client) -> None:
+async def test_info_validation(monkeypatch: pytest.MonkeyPatch, test_client) -> None:
     config = Config.get_instance()
-    seen = _patch_thread(monkeypatch, ytdlp_router, config, "https://bad.example/info")
+    seen = _reject_url(monkeypatch, ytdlp_router, "https://bad.example/info")
 
     async def handler(request):
         return await ytdlp_router.get_info(request, cache=None, config=config)
@@ -83,16 +76,15 @@ async def test_info_thread(monkeypatch: pytest.MonkeyPatch, test_client) -> None
 
     assert response.status == 400
     assert (await response.json())["error"] == "Invalid hostname."
-    assert seen == {"to_thread": True, "validate": True}
+    assert seen == {"validate": True}
 
 
 @pytest.mark.asyncio
-async def test_archive_ids_thread(monkeypatch: pytest.MonkeyPatch, test_client) -> None:
-    config = Config.get_instance()
-    seen = _patch_thread(monkeypatch, ytdlp_router, config, "https://bad.example/archive")
+async def test_archive_validation(monkeypatch: pytest.MonkeyPatch, test_client) -> None:
+    seen = _reject_url(monkeypatch, ytdlp_router, "https://bad.example/archive")
 
     async def handler(request):
-        return await ytdlp_router.get_archive_ids(request, config)
+        return await ytdlp_router.get_archive_ids(request)
 
     client = await test_client({"get_archive_ids": handler})
     response = await client.post(url_for("get_archive_ids"), json=["https://bad.example/archive"])
@@ -108,4 +100,4 @@ async def test_archive_ids_thread(monkeypatch: pytest.MonkeyPatch, test_client) 
             "error": "Invalid hostname.",
         }
     ]
-    assert seen == {"to_thread": True, "validate": True}
+    assert seen == {"validate": True}

--- a/app/tests/test_cache.py
+++ b/app/tests/test_cache.py
@@ -272,15 +272,6 @@ class TestCache:
         assert self.cache.get("key2") == "value2", "Should keep non-expired key"
 
     @pytest.mark.asyncio
-    async def test_cleanup_with_empty_cache(self):
-        """Test that _cleanup handles empty cache without errors."""
-        # Clear cache first
-        self.cache.clear()
-
-        # Should not raise any errors
-        await self.cache.cleanup()
-
-    @pytest.mark.asyncio
     async def test_attach_registers_with_services(self):
         """Test that attach method registers cache with Services and schedules cleanup."""
         from app.library.Scheduler import Scheduler

--- a/app/tests/test_cf_solver_handler.py
+++ b/app/tests/test_cf_solver_handler.py
@@ -213,30 +213,6 @@ class TestCFSolverRH:
         mock_director.close.assert_called_once()
         assert self.handler._fallback_director is None
 
-    def test_close_no_director(self):
-        """Test closing handler when no director exists."""
-        self.handler._fallback_director = None
-        self.handler.close()
-
-    def test_check_extensions(self):
-        """Test extension checking."""
-        extensions = {
-            "timeout": 30,
-            "legacy_ssl": True,
-            "other": "value",
-        }
-
-        self.handler._check_extensions(extensions)
-
-    def test_validate(self):
-        """Test request validation."""
-        request = Mock()
-        request.url = "https://example.com"
-        request.proxies = None
-        request.extensions = {}
-
-        self.handler._validate(request)
-
     def test_solve(self):
         """Test solving challenge."""
         request = Mock()

--- a/app/tests/test_datastore_pagination.py
+++ b/app/tests/test_datastore_pagination.py
@@ -135,26 +135,6 @@ class TestDataStorePagination:
         finally:
             await db.close()
 
-    async def test_pagination_order_desc(self):
-        """Test pagination with descending order (newest first)."""
-        db = await make_db(data=100)
-        try:
-            datastore = DataStore(type=StoreType.HISTORY, connection=db)
-            items, _, _, _ = await datastore.get_items_paginated(page=1, per_page=5, order="DESC")
-            assert len(items) == 5
-        finally:
-            await db.close()
-
-    async def test_pagination_order_asc(self):
-        """Test pagination with ascending order (oldest first)."""
-        db = await make_db(data=100)
-        try:
-            datastore = DataStore(type=StoreType.HISTORY, connection=db)
-            items, _, _, _ = await datastore.get_items_paginated(page=1, per_page=5, order="ASC")
-            assert len(items) == 5
-        finally:
-            await db.close()
-
     async def test_pagination_invalid_page(self):
         """Test pagination with invalid page number."""
         db = await make_db(data=100)

--- a/app/tests/test_download.py
+++ b/app/tests/test_download.py
@@ -506,7 +506,6 @@ class TestDownloadFlow:
             temp_path = "/tmp"
             output_template = "%(title)s.%(ext)s"
             output_template_chapter = "%(title)s.%(ext)s"
-            disable_exec = False
 
             @staticmethod
             def get_instance():

--- a/app/tests/test_download_utils.py
+++ b/app/tests/test_download_utils.py
@@ -212,35 +212,12 @@ class TestDataUtilities:
 
 
 class TestStateUtilities:
-    def test_stale_finished(self) -> None:
+    @pytest.mark.parametrize("status", ["finished", "error", "cancelled", "downloading", "postprocessing"])
+    def test_stale_status(self, status: str) -> None:
         result = is_download_stale(
-            started_time=int(time.time()) - 500, current_status="finished", is_running=False, auto_start=True
+            started_time=int(time.time()) - 500, current_status=status, is_running=False, auto_start=True
         )
-        assert result is False, "Finished downloads are never stale"
-
-    def test_stale_terminal_status_error(self) -> None:
-        result = is_download_stale(
-            started_time=int(time.time()) - 500, current_status="error", is_running=False, auto_start=True
-        )
-        assert result is False, "Error downloads are never stale"
-
-    def test_stale_cancelled(self) -> None:
-        result = is_download_stale(
-            started_time=int(time.time()) - 500, current_status="cancelled", is_running=False, auto_start=True
-        )
-        assert result is False, "Cancelled downloads are never stale"
-
-    def test_stale_downloading(self) -> None:
-        result = is_download_stale(
-            started_time=int(time.time()) - 500, current_status="downloading", is_running=False, auto_start=True
-        )
-        assert result is False, "Downloading status is never stale"
-
-    def test_stale_postprocessing(self) -> None:
-        result = is_download_stale(
-            started_time=int(time.time()) - 500, current_status="postprocessing", is_running=False, auto_start=True
-        )
-        assert result is False, "Postprocessing status is never stale"
+        assert result is False, f"{status} downloads are never stale"
 
     def test_stale_not_auto_start(self) -> None:
         result = is_download_stale(

--- a/app/tests/test_encoder.py
+++ b/app/tests/test_encoder.py
@@ -16,18 +16,11 @@ class TestEncoder:
         """Set up test fixtures."""
         self.encoder = Encoder()
 
-    def test_path_serialization(self):
-        """Test that Path objects are serialized as strings."""
-        path = Path("/tmp/test/file.txt")
+    @pytest.mark.parametrize("path", [Path("/tmp/test/file.txt"), Path("relative/path/file.txt")])
+    def test_path_serialization(self, path: Path) -> None:
         result = self.encoder.default(path)
-        assert result == "/tmp/test/file.txt"
+        assert result == str(path)
         assert isinstance(result, str)
-
-    def test_path_serialization_relative(self):
-        """Test that relative Path objects are serialized correctly."""
-        path = Path("relative/path/file.txt")
-        result = self.encoder.default(path)
-        assert result == "relative/path/file.txt"
 
     def test_date_serialization(self):
         """Test that date objects are serialized as strings."""

--- a/app/tests/test_generic_browser.py
+++ b/app/tests/test_generic_browser.py
@@ -445,18 +445,12 @@ def test_select_driver_selenium(monkeypatch: pytest.MonkeyPatch) -> None:
     assert ie._select_driver("selenium+http://browser:9222") is generic_browser.SeleniumDriver
 
 
-def test_select_driver_playwright_ws(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("url", ["playwright+http://playwright:9222/", "playwright+http://chrome:9222/"])
+def test_select_driver_playwright(monkeypatch: pytest.MonkeyPatch, url: str) -> None:
     ie = _make_ie()
     monkeypatch.setattr(generic_browser.PlaywrightDriver, "is_available", staticmethod(lambda: True))
 
-    assert ie._select_driver("playwright+http://playwright:9222/") is generic_browser.PlaywrightDriver
-
-
-def test_select_driver_playwright_cdp(monkeypatch: pytest.MonkeyPatch) -> None:
-    ie = _make_ie()
-    monkeypatch.setattr(generic_browser.PlaywrightDriver, "is_available", staticmethod(lambda: True))
-
-    assert ie._select_driver("playwright+http://chrome:9222/") is generic_browser.PlaywrightDriver
+    assert ie._select_driver(url) is generic_browser.PlaywrightDriver
 
 
 def _playwright_mocks(monkeypatch: pytest.MonkeyPatch, contexts: list[Mock]) -> tuple[Mock, Mock]:

--- a/app/tests/test_itemdto.py
+++ b/app/tests/test_itemdto.py
@@ -192,28 +192,6 @@ class TestItemDTO:
         assert dto.name() == 'id="abc", title="Title"'
         assert isinstance(dto.get_id(), str)
 
-    def test_archive_add_delete_paths(self):
-        dto = ItemDTO(id="id", title="t", url="u", folder="f")
-        assert dto.archive_add() is False, "Precondition not met yet"
-
-        # Set up to allow add
-        dto.archive_id = "arch"
-        dto._archive_file = "var/tests/archive.txt"
-        dto.is_archivable = True
-        dto.is_archived = False
-
-        with patch("app.library.ItemDTO.archive_add", return_value=True) as m_add:
-            ok = dto.archive_add()
-            assert ok is True
-            m_add.assert_called_once()
-
-        # Delete requires is_archived True
-        dto.is_archived = True
-        with patch("app.library.ItemDTO.archive_delete") as m_del:
-            ok2 = dto.archive_delete()
-            assert ok2 is True
-            m_del.assert_called_once()
-
     def test_get_file_method(self):
         """Test ItemDTO get_file method returns correct path."""
         # Create ItemDTO with filename but no folder

--- a/app/tests/test_package_installer.py
+++ b/app/tests/test_package_installer.py
@@ -241,17 +241,6 @@ class TestActionAndCheck:
         inst.action("pkg")
         mock_install.assert_called_once_with("pkg", version=None)
 
-    def test_no_packages_or_path(self, tmp_path: Path) -> None:
-        # No packages
-        inst = PackageInstaller(pkg_path=tmp_path)
-        pkgs = Packages(env=None, file=None, upgrade=False)
-        inst.check(pkgs)  # Should do nothing
-
-        # No user_site => early return
-        inst2 = PackageInstaller(pkg_path=None)
-        pkgs2 = Packages(env="a b", file=None, upgrade=False)
-        inst2.check(pkgs2)
-
     @patch.object(PackageInstaller, "action")
     def test_check_runs_all(self, mock_action, tmp_path: Path) -> None:
         inst = PackageInstaller(pkg_path=tmp_path)

--- a/app/tests/test_utils.py
+++ b/app/tests/test_utils.py
@@ -1278,7 +1278,8 @@ class TestGetFileSidecar:
             nfo_file.write_text("nfo content")
 
             result = get_file_sidecar(video_file)
-            assert isinstance(result, dict)  # Returns dict, not list
+            assert result["subtitle"] == [{"file": srt_file, "lang": "und", "name": "SRT (1) - und"}]
+            assert result["text"] == [{"file": nfo_file}]
 
     def test_file_sidecar_no_files(self):
         """Test getting sidecar files when none exist."""
@@ -1287,7 +1288,7 @@ class TestGetFileSidecar:
             video_file.write_text("video content")
 
             result = get_file_sidecar(video_file)
-            assert isinstance(result, dict)  # Returns dict, not list
+            assert result == {}
 
 
 class TestCheckId:

--- a/app/tests/test_utils.py
+++ b/app/tests/test_utils.py
@@ -33,7 +33,6 @@ from app.library.Utils import (
     get_mime_type,
     get_possible_images,
     init_class,
-    is_private_address,
     load_cookies,
     merge_dict,
     move_file,
@@ -1037,27 +1036,6 @@ class TestMergeDict:
         return current
 
 
-class TestIsPrivateAddress:
-    """Test the is_private_address function."""
-
-    def test_is_private_address_localhost(self):
-        """Test localhost addresses."""
-        assert is_private_address("localhost") is True
-        assert is_private_address("127.0.0.1") is True
-
-    def test_private_address_private_ranges(self):
-        """Test private IP ranges."""
-        assert is_private_address("192.168.1.1") is True
-        assert is_private_address("10.0.0.1") is True
-        assert is_private_address("172.16.0.1") is True
-
-    def test_is_private_address_public(self):
-        """Test public addresses."""
-        assert is_private_address("8.8.8.8") is False
-        assert is_private_address("google.com") is False
-        assert is_private_address("1.1.1.1") is False
-
-
 class TestDeleteDir:
     """Test the delete_dir function."""
 
@@ -1276,8 +1254,13 @@ class TestValidateUrl:
                 validate_url("https://example.com")
             return
 
-        result = validate_url("https://example.com", allow_internal=True)
+        result = validate_url("https://example.com")
         assert result is True
+
+    @pytest.mark.parametrize("url", ["", "ftp://example.com", "https:///missing-host"])
+    def test_rejects_format(self, url: str) -> None:
+        with pytest.raises(ValueError):
+            validate_url(url)
 
 
 class TestGetFileSidecar:

--- a/ui/app/components/AccountModal.vue
+++ b/ui/app/components/AccountModal.vue
@@ -4,19 +4,45 @@
     :title="t('auth.account')"
     :description="t('auth.accountDescription')"
     :dismissible="!busy"
-    :ui="{ content: 'w-full sm:max-w-4xl', body: 'max-h-[80vh] overflow-y-auto p-4 sm:p-6' }"
+    :ui="{
+      content: 'w-full sm:max-w-2xl',
+      body: 'max-h-[75vh] overflow-y-auto p-4 sm:p-5',
+      footer: 'px-4 pb-4 sm:px-5 sm:pb-5',
+    }"
   >
     <template #body>
-      <div class="space-y-5">
-        <section class="ytp-card space-y-5 p-4 sm:p-6">
-          <div class="flex flex-wrap items-start justify-between gap-4">
-            <div class="flex items-start gap-3">
-              <span class="ytp-section-icon"
-                ><UIcon name="i-lucide-user-round-cog" class="size-5"
-              /></span>
+      <div v-if="loading && !username" class="flex min-h-48 items-center justify-center">
+        <UIcon name="i-lucide-loader-circle" class="size-8 animate-spin text-toned" />
+        <span class="sr-only">{{ t('common.loading') }}</span>
+      </div>
+      <div v-else-if="loadFailed" class="space-y-3">
+        <UAlert
+          color="error"
+          variant="soft"
+          icon="i-lucide-circle-alert"
+          :title="t('auth.errorTitle')"
+          :description="t('common.failedFetch')"
+        />
+        <UButton
+          color="neutral"
+          variant="outline"
+          icon="i-lucide-refresh-cw"
+          :loading="loading"
+          @click="load"
+        >
+          {{ t('common.retry') }}
+        </UButton>
+      </div>
+      <div v-else class="space-y-6">
+        <section class="space-y-3">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div class="flex min-w-0 items-center gap-3">
+              <span class="ytp-detail-icon">
+                <UIcon name="i-lucide-user-round-cog" class="size-4" />
+              </span>
               <div>
                 <h2 class="font-semibold text-highlighted">{{ t('auth.accountDetails') }}</h2>
-                <p class="mt-1 text-sm text-toned">{{ t('auth.accountDetailsDescription') }}</p>
+                <p class="text-sm text-toned">{{ t('auth.accountDetailsDescription') }}</p>
               </div>
             </div>
             <UButton
@@ -24,30 +50,32 @@
               variant="outline"
               size="sm"
               icon="i-lucide-pencil"
+              :disabled="busy"
               @click="openEdit"
             >
               {{ t('common.edit') }}
             </UButton>
           </div>
-          <div class="rounded-lg border border-default bg-elevated/40 p-4">
-            <p class="text-xs font-semibold uppercase tracking-wide text-toned">
-              {{ t('auth.username') }}
-            </p>
-            <p class="mt-1 break-all text-lg font-semibold text-highlighted">
-              {{ username || t('auth.account') }}
-            </p>
+          <div
+            class="flex min-w-0 items-center gap-3 rounded-sm border border-default bg-elevated/40 p-3"
+          >
+            <UIcon name="i-lucide-user" class="size-4 shrink-0 text-toned" />
+            <div class="min-w-0">
+              <p class="text-xs font-medium text-toned">{{ t('auth.username') }}</p>
+              <p class="truncate font-semibold text-highlighted">{{ username }}</p>
+            </div>
           </div>
         </section>
 
-        <section class="ytp-card space-y-5 p-4 sm:p-6">
-          <div class="flex flex-wrap items-start justify-between gap-4">
-            <div class="flex items-start gap-3">
-              <span class="ytp-section-icon"
-                ><UIcon name="i-lucide-key-round" class="size-5"
-              /></span>
+        <section class="space-y-3 border-t border-default pt-5">
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <div class="flex min-w-0 items-center gap-3">
+              <span class="ytp-detail-icon">
+                <UIcon name="i-lucide-key-round" class="size-4" />
+              </span>
               <div>
                 <h2 class="font-semibold text-highlighted">{{ t('auth.apiKeys') }}</h2>
-                <p class="mt-1 text-sm text-toned">{{ t('auth.apiKeysDescription') }}</p>
+                <p class="text-sm text-toned">{{ t('auth.apiKeysDescription') }}</p>
               </div>
             </div>
             <UButton
@@ -55,38 +83,48 @@
               variant="outline"
               size="sm"
               icon="i-lucide-plus"
+              :disabled="busy"
               @click="openCreateKey"
             >
               {{ t('auth.createKey') }}
             </UButton>
           </div>
-          <UAlert
+          <UEmpty
             v-if="!keys.length"
-            color="neutral"
-            variant="soft"
             icon="i-lucide-key-round"
             :title="t('auth.noApiKeys')"
             :description="t('auth.noApiKeysDescription')"
+            class="py-8"
           />
-          <div v-else class="space-y-3">
+          <div v-else class="divide-y divide-default rounded-sm border border-default">
             <div
               v-for="key in keys"
               :key="key.id"
-              class="flex flex-col gap-4 rounded-lg border border-default p-4 sm:flex-row sm:items-center sm:justify-between"
+              class="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between"
             >
-              <div class="flex min-w-0 items-start gap-3">
-                <UIcon name="i-lucide-key-round" class="mt-0.5 size-5 shrink-0 text-toned" />
-                <div class="min-w-0">
-                  <p class="truncate font-semibold text-highlighted">{{ key.name }}</p>
-                  <div class="mt-1 flex flex-wrap items-center gap-2 text-xs text-toned">
-                    <UBadge color="neutral" variant="soft">...{{ key.hint }}</UBadge>
+              <div class="min-w-0">
+                <p class="truncate font-medium text-highlighted">{{ key.name }}</p>
+                <div class="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-toned">
+                  <code class="rounded-sm bg-elevated px-1.5 py-0.5 font-mono"
+                    >...{{ key.hint }}</code
+                  >
+                  <UTooltip :text="formatDateTime(key.created_at, locale)">
                     <span>{{
-                      t('auth.createdAt', { date: formatDateTime(key.created_at, locale) })
+                      t('auth.createdAt', {
+                        date: formatRelativeTime(key.created_at, locale),
+                      })
                     }}</span>
-                    <span v-if="key.last_used_at">{{
-                      t('auth.lastUsedAt', { date: formatDateTime(key.last_used_at, locale) })
+                  </UTooltip>
+                  <UTooltip
+                    v-if="key.last_used_at"
+                    :text="formatDateTime(key.last_used_at, locale)"
+                  >
+                    <span>{{
+                      t('auth.lastUsedAt', {
+                        date: formatRelativeTime(key.last_used_at, locale),
+                      })
                     }}</span>
-                  </div>
+                  </UTooltip>
                 </div>
               </div>
               <UButton
@@ -95,6 +133,8 @@
                 size="sm"
                 icon="i-lucide-trash-2"
                 class="shrink-0 self-start sm:self-auto"
+                :loading="revoking === key.id"
+                :disabled="revoking !== null"
                 @click="revoke(key.id)"
               >
                 {{ t('auth.revoke') }}
@@ -145,6 +185,7 @@
             class="w-full"
             icon="i-lucide-user"
             autocomplete="username"
+            :disabled="saving"
         /></UFormField>
         <UFormField :label="t('auth.currentPassword')" name="currentPassword" required
           ><UInput
@@ -154,6 +195,7 @@
             :type="showCurrentPassword ? 'text' : 'password'"
             autocomplete="current-password"
             required
+            :disabled="saving"
             :trailing-icon="showCurrentPassword ? 'i-lucide-eye-off' : 'i-lucide-eye'"
             @click:trailing="showCurrentPassword = !showCurrentPassword"
         /></UFormField>
@@ -164,6 +206,7 @@
             icon="i-lucide-lock-keyhole"
             :type="showNewPassword ? 'text' : 'password'"
             autocomplete="new-password"
+            :disabled="saving"
             :trailing-icon="showNewPassword ? 'i-lucide-eye-off' : 'i-lucide-eye'"
             @click:trailing="showNewPassword = !showNewPassword"
         /></UFormField>
@@ -181,6 +224,7 @@
         ><UButton
           type="submit"
           form="accountForm"
+          color="primary"
           icon="i-lucide-save"
           :loading="saving"
           :disabled="saving"
@@ -199,7 +243,7 @@
     @update:open="handleCreateOpenChange"
   >
     <template #body
-      ><form id="keyForm" @submit.prevent="createKey">
+      ><form id="keyForm" class="space-y-4" @submit.prevent="createKey">
         <UFormField :label="t('auth.keyName')" name="keyName" required
           ><UInput
             v-model="keyName"
@@ -207,6 +251,7 @@
             icon="i-lucide-key-round"
             autocomplete="off"
             required
+            :disabled="creating"
         /></UFormField></form
     ></template>
     <template #footer
@@ -221,6 +266,7 @@
         ><UButton
           type="submit"
           form="keyForm"
+          color="primary"
           icon="i-lucide-plus"
           :loading="creating"
           :disabled="creating || !keyName.trim()"
@@ -238,8 +284,8 @@
     :dismissible="false"
   >
     <template #body
-      ><div class="flex items-start gap-3 rounded-lg border border-default bg-elevated/50 p-4">
-        <UIcon name="i-lucide-key-round" class="mt-0.5 size-5 shrink-0 text-toned" />
+      ><div class="flex items-start gap-3 rounded-sm border border-default bg-elevated/50 p-3">
+        <UIcon name="i-lucide-key-round" class="mt-0.5 size-4 shrink-0 text-toned" />
         <code class="min-w-0 break-all font-mono text-sm text-highlighted">{{ newKey }}</code>
       </div></template
     >
@@ -248,7 +294,9 @@
         <UButton color="neutral" variant="outline" icon="i-lucide-check" @click="closeNewKey">{{
           t('common.ok')
         }}</UButton
-        ><UButton icon="i-lucide-copy" @click="copyKey">{{ t('common.copy') }}</UButton>
+        ><UButton color="primary" icon="i-lucide-copy" @click="copyKey">{{
+          t('common.copy')
+        }}</UButton>
       </div></template
     >
   </UModal>
@@ -260,6 +308,7 @@ import { useDirtyCloseGuard } from '~/composables/useDirtyCloseGuard';
 import { useDirtyState } from '~/composables/useDirtyState';
 import { ApiError, copyText, ensure_api_success, parse_api_error, request } from '~/utils';
 import { formatDateTime } from '~/utils/date';
+import { formatRelativeTime } from '~/utils/relativeTime';
 
 type ApiKey = {
   id: number;
@@ -281,15 +330,20 @@ const keyName = ref('');
 const newKey = ref('');
 const keys = ref<ApiKey[]>([]);
 const loading = ref(false);
+const loadFailed = ref(false);
 const saving = ref(false);
 const creating = ref(false);
 const loggingOut = ref(false);
+const revoking = ref<number | null>(null);
 const editOpen = ref(false);
 const createOpen = ref(false);
 const keyOpen = ref(true);
 const showCurrentPassword = ref(false);
 const showNewPassword = ref(false);
-const busy = computed(() => loading.value || saving.value || creating.value || loggingOut.value);
+const busy = computed(
+  () =>
+    loading.value || saving.value || creating.value || loggingOut.value || revoking.value !== null,
+);
 const editSource = computed(() => ({
   username: editUsername.value,
   currentPassword: currentPassword.value,
@@ -335,6 +389,7 @@ const report = async (error: unknown): Promise<void> => {
 const load = async (): Promise<void> => {
   if (loading.value) return;
   loading.value = true;
+  loadFailed.value = false;
   try {
     const me = await request('/api/auth/me');
     await ensure_api_success(me);
@@ -345,6 +400,7 @@ const load = async (): Promise<void> => {
     await ensure_api_success(response);
     keys.value = ((await response.json()) as { items: ApiKey[] }).items;
   } catch (error) {
+    loadFailed.value = true;
     await report(error);
   } finally {
     loading.value = false;
@@ -412,6 +468,7 @@ const copyKey = (): void => {
   }
 };
 const revoke = async (id: number): Promise<void> => {
+  if (revoking.value !== null) return;
   if (
     !(await confirm(t('auth.revokeConfirm'), {
       confirmText: t('auth.revoke'),
@@ -419,12 +476,15 @@ const revoke = async (id: number): Promise<void> => {
     }))
   )
     return;
+  revoking.value = id;
   try {
     const response = await request(`/api/auth/api-keys/${id}`, { method: 'DELETE' });
     await ensure_api_success(response);
     await load();
   } catch (error) {
     await report(error);
+  } finally {
+    revoking.value = null;
   }
 };
 const logout = async (): Promise<void> => {

--- a/ui/tests/composables/useApiErrorMessage.test.ts
+++ b/ui/tests/composables/useApiErrorMessage.test.ts
@@ -77,13 +77,8 @@ describe('useApiErrorMessage', () => {
     expect(result).toBe('Validation failed on field x.');
   });
 
-  it('returns localized generic error for null payload', () => {
-    const result = messageFor(null);
-    expect(result).toBe('errors.UNKNOWN');
-  });
-
-  it('returns localized generic error for undefined payload', () => {
-    const result = messageFor(undefined);
+  it.each([null, undefined])('returns localized generic error for %s payload', (payload) => {
+    const result = messageFor(payload);
     expect(result).toBe('errors.UNKNOWN');
   });
 

--- a/ui/tests/composables/useAppLocale.test.ts
+++ b/ui/tests/composables/useAppLocale.test.ts
@@ -63,13 +63,6 @@ globalThis.computed = (fn: () => unknown) => ({
 const { useAppLocale } = await import('~/composables/useAppLocale');
 
 describe('useAppLocale', () => {
-  it('returns en as default locale', () => {
-    currentLocale = 'en';
-    localeRef.value = 'en';
-    const { locale } = useAppLocale();
-    expect(locale.value).toBe('en');
-  });
-
   it('direction is ltr for English', () => {
     currentLocale = 'en';
     localeRef.value = 'en';
@@ -94,18 +87,4 @@ describe('useAppLocale', () => {
     expect(locale.value).toBe('ar');
   });
 
-  it('changes locale back to en', async () => {
-    currentLocale = 'ar';
-    localeRef.value = 'ar';
-    const { locale, changeLocale } = useAppLocale();
-    await changeLocale('en');
-    expect(locale.value).toBe('en');
-  });
-
-  it('exposes locales list', () => {
-    currentLocale = 'en';
-    localeRef.value = 'en';
-    const { locales } = useAppLocale();
-    expect(locales.value.length).toBe(2);
-  });
 });

--- a/ui/tests/composables/useConditions.test.ts
+++ b/ui/tests/composables/useConditions.test.ts
@@ -94,7 +94,6 @@ describe('useConditions', () => {
       const conditions = useConditions()
       await conditions.loadConditions()
 
-      expect(conditions.conditions.value).toHaveLength(1)
       expect(conditions.conditions.value[0]).toEqual(mockCondition)
       expect(conditions.pagination.value).toEqual(mockPagination)
       expect(conditions.lastError.value).toBeNull()
@@ -288,7 +287,6 @@ describe('useConditions', () => {
       })
 
       expect(result).toEqual(testResponse)
-      expect(result?.status).toBe(true)
       requestSpy.mockRestore()
     })
 

--- a/ui/tests/composables/useTasks.test.ts
+++ b/ui/tests/composables/useTasks.test.ts
@@ -101,7 +101,6 @@ describe('useTasks', () => {
       const tasks = useTasks()
       await tasks.loadTasks()
 
-      expect(tasks.tasks.value).toHaveLength(1)
       expect(tasks.tasks.value[0]).toEqual(mockTask)
       expect(tasks.pagination.value).toEqual(mockPagination)
       expect(tasks.lastError.value).toBeNull()
@@ -443,8 +442,6 @@ describe('useTasks', () => {
         })
 
         expect(result).toEqual(inspectResponse)
-        expect(result?.matched).toBe(true)
-        expect(result?.handler).toBe('YoutubeHandler')
       } finally {
         requestSpy.mockRestore()
       }
@@ -595,7 +592,6 @@ describe('useTasks', () => {
       const result = await tasks.generateTaskMetadata(1)
 
       expect(result).toEqual(metadataResponse)
-      expect(result?.status).toBe('success')
       expect(tasks.lastError.value).toBeNull()
       requestSpy.mockRestore()
     })
@@ -685,8 +681,6 @@ describe('useTasks', () => {
         'name: Field required, url: Invalid URL format',
       )
       expect(tasks.lastError.value).toBe('name: Field required, url: Invalid URL format')
-      expect(tasks.lastError.value).toContain('name: Field required')
-      expect(tasks.lastError.value).toContain('url: Invalid URL format')
       requestSpy.mockRestore()
     })
   })

--- a/ui/tests/utils/index.test.ts
+++ b/ui/tests/utils/index.test.ts
@@ -168,47 +168,28 @@ describe('string manipulation helpers', () => {
     expect(result).toBe('Hello YTPTube!');
   });
 
-  it('itrim_edges', () => {
-    expect(utils.iTrim('--value--', '-', 'both')).toBe('value');
-    expect(utils.iTrim('::value', ':', 'start')).toBe('value');
-    expect(utils.iTrim('value::', ':', 'end')).toBe('value');
-  });
-
-  it('itrim_slash', () => {
-    expect(utils.iTrim('//value//', '/', 'both')).toBe('value');
-    expect(utils.iTrim('/value', '/', 'start')).toBe('value');
-    expect(utils.iTrim('value/', '/', 'end')).toBe('value');
-    expect(utils.iTrim('///multiple///', '/', 'both')).toBe('multiple');
-  });
-
-  it('itrim_backslash', () => {
-    expect(utils.iTrim('\\\\value\\\\', '\\', 'both')).toBe('value');
-    expect(utils.iTrim('\\value', '\\', 'start')).toBe('value');
-    expect(utils.iTrim('value\\', '\\', 'end')).toBe('value');
-  });
-
-  it('itrim_hyphen', () => {
-    expect(utils.iTrim('--value--', '-', 'both')).toBe('value');
-    expect(utils.iTrim('-value', '-', 'start')).toBe('value');
-    expect(utils.iTrim('value-', '-', 'end')).toBe('value');
-    expect(utils.iTrim('---multiple---', '-', 'both')).toBe('multiple');
-  });
-
-  it('itrim_caret', () => {
-    expect(utils.iTrim('^^value^^', '^', 'both')).toBe('value');
-    expect(utils.iTrim('^value', '^', 'start')).toBe('value');
-    expect(utils.iTrim('value^', '^', 'end')).toBe('value');
+  it.each([
+    ['--value--', '-', 'both', 'value'],
+    ['::value', ':', 'start', 'value'],
+    ['value::', ':', 'end', 'value'],
+    ['///multiple///', '/', 'both', 'multiple'],
+    ['---multiple---', '-', 'both', 'multiple'],
+    ['\\\\value\\\\', '\\', 'both', 'value'],
+    ['\\value', '\\', 'start', 'value'],
+    ['value\\', '\\', 'end', 'value'],
+    ['^^value^^', '^', 'both', 'value'],
+    ['^value', '^', 'start', 'value'],
+    ['value^', '^', 'end', 'value'],
+    ['..value..', '.', 'both', 'value'],
+    ['.value', '.', 'start', 'value'],
+    ['value.', '.', 'end', 'value'],
+  ] as const)('itrim %s', (input, delimiter, mode, expected) => {
+    expect(utils.iTrim(input, delimiter, mode)).toBe(expected);
   });
 
   it('itrim_brackets', () => {
     expect(utils.iTrim('[[value]]', '[', 'both')).toBe('value]]');
     expect(utils.iTrim(']]value[[', ']', 'both')).toBe('value[[');
-  });
-
-  it('itrim_dot', () => {
-    expect(utils.iTrim('..value..', '.', 'both')).toBe('value');
-    expect(utils.iTrim('.value', '.', 'start')).toBe('value');
-    expect(utils.iTrim('value.', '.', 'end')).toBe('value');
   });
 
   it('itrim_regex_chars', () => {


### PR DESCRIPTION
* Removed the obsolete `YTP_ALLOW_INTERNAL_URLS`, and `YTP_DISABLE_EXEC` env options.
* Updated security documentation in `SECURITY.md` to clarify that YTPTube does not sandbox outbound network access, and that authenticated administrators can cause requests to internal services. 
* Removed unused imports and obsolete test functions for better code clarity and maintainability. 
* refactored account modal page to be inline with our established design.