### PR TITLE
refactor: support external yt-dlp in execuable builds.

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -40,6 +40,7 @@ or the `environment:` section in `compose.yaml` file.
 | YTP_EXTRACT_INFO_KEEP_ALIVE     | Keep extract info worker processes alive between requests           | `false`               |
 | YTP_PIP_PACKAGES                | A space separated list of pip packages to install                   | `(not_set)`           |
 | YTP_PIP_IGNORE_UPDATES          | Do not update the custom pip packages                               | `false`               |
+| YTP_PYTHON_PATH                 | Application package directories to load before config-local and bundled packages | `(not_set)` |
 | YTP_PICTURES_BACKENDS           | A comma separated list of pictures urls to use                      | `(not_set)`           |
 | YTP_BROWSER_CONTROL_ENABLED     | Whether to enable the file browser actions                          | `false`               |
 | YTP_YTDLP_AUTO_UPDATE           | Whether to enable the auto update for yt-dlp                        | `true`                |
@@ -231,6 +232,75 @@ YTP_YTDLP_VERSION=2025.07.21 or master or nightly
 ```
 
 Then restart the container to apply the changes.
+
+# Manually update yt-dlp in native executable?
+
+Stop YTPTube before changing its Python packages. Use a Python interpreter with the same major and minor version and
+architecture as the native build.
+
+Install yt-dlp into the versioned package directory under YTPTube's config location. On Linux:
+
+```bash
+export YTP_CONFIG_PATH="${XDG_CONFIG_HOME:-$HOME/.config}/ytptube"
+TARGET="$YTP_CONFIG_PATH/python3.13-packages"
+mkdir -p "$TARGET"
+python3.13 -m pip install --upgrade --target "$TARGET" "yt-dlp[default]"
+./YTPTube
+```
+
+On macOS, use `export YTP_CONFIG_PATH="$HOME/Library/Application Support/ytptube"` before the remaining commands.
+These are the native executable's default config locations, so later launches find the override without requiring a
+custom environment variable.
+
+On Windows, use PowerShell and a matching 64-bit or ARM64 Python installation:
+
+```powershell
+$env:YTP_CONFIG_PATH = Join-Path $env:LOCALAPPDATA "arabcoders\ytptube"
+$target = Join-Path $env:YTP_CONFIG_PATH "python3.13-packages"
+New-Item -ItemType Directory -Force $target | Out-Null
+py -3.13 -m pip install --upgrade --target $target "yt-dlp[default]"
+.\YTPTube.exe
+```
+
+The same target supports pinned, nightly, and master versions:
+
+```bash
+# Pinned release
+python3.13 -m pip install --upgrade --target "$TARGET" "yt-dlp[default]==2026.01.26"
+
+# Nightly channel
+python3.13 -m pip install --upgrade --pre --target "$TARGET" "yt-dlp[default]"
+
+# Master channel; requires Git
+python3.13 -m pip install --upgrade --target "$TARGET" \
+  "yt-dlp[default] @ git+https://github.com/yt-dlp/yt-dlp.git@master"
+```
+
+The equivalent PowerShell commands use the `$target` variable defined above:
+
+```powershell
+# Pinned release
+py -3.13 -m pip install --upgrade --target $target "yt-dlp[default]==2026.01.26"
+
+# Nightly channel
+py -3.13 -m pip install --upgrade --pre --target $target "yt-dlp[default]"
+
+# Master channel; requires Git
+py -3.13 -m pip install --upgrade --target $target "yt-dlp[default] @ git+https://github.com/yt-dlp/yt-dlp.git@master"
+```
+
+To keep packages elsewhere, set `YTP_PYTHON_PATH` when starting YTPTube. For application packages loaded after startup,
+such as yt-dlp, these directories take precedence over the config-local directory and bundled copy:
+
+```bash
+YTP_PYTHON_PATH="/path/to/packages" ./YTPTube
+```
+
+Separate multiple directories with `:` on Linux and macOS or `;` on Windows. Keep `YTP_PYTHON_PATH` set on every
+launch. On Windows, for example, use `$env:YTP_PYTHON_PATH = "C:\path\to\packages"` before running `YTPTube.exe`.
+Only add trusted directories that cannot be modified by untrusted users, because Python modules loaded from these
+locations execute with the same permissions as YTPTube. Reinstall the override when a future native build changes its
+bundled Python major or minor version.
 
 # Custom output template placeholders
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Extract the archive and run the `YTPTube` binary (or `YTPTube.exe` on Windows).
 If you plan to use the built-in video player, make sure `ffmpeg` is installed and available on `PATH`.
 
 > [!NOTE]
-> 1- Automatic `yt-dlp` and package updates are not avaliable in the native execuables.
+> 1- Automatic `yt-dlp` and package updates are not available in the native executables. See [Manually update yt-dlp in native executable](FAQ.md#manually-update-yt-dlp-in-native-executable).
 > 
 > 2- You need to manually install [ffmpeg](https://github.com/jellyfin/jellyfin-ffmpeg/releases) and [deno](https://deno.land/#installation) and have them in your `PATH`.
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,12 +2,24 @@ import os
 import sys
 from pathlib import Path
 
-if base_dir := os.environ.get("YTP_CONFIG_PATH"):
-    base_dir = Path(base_dir)
-    user_site = base_dir / f"python{sys.version_info.major}.{sys.version_info.minor}-packages"
 
-    if not user_site.exists():
-        user_site.mkdir(parents=True, exist_ok=True)
+def _add_package_paths() -> None:
+    paths: list[Path] = []
+    if value := os.environ.get("YTP_PYTHON_PATH"):
+        paths.extend(path for item in value.split(os.pathsep) if (path := Path(item).expanduser()).is_dir())
 
-    if user_site.is_dir() and str(user_site) not in sys.path:
-        sys.path.insert(0, str(user_site))
+    if base_dir := os.environ.get("YTP_CONFIG_PATH"):
+        user_site = Path(base_dir) / f"python{sys.version_info.major}.{sys.version_info.minor}-packages"
+        if not user_site.exists():
+            user_site.mkdir(parents=True, exist_ok=True)
+        if user_site.is_dir():
+            paths.append(user_site)
+
+    for path in reversed(paths):
+        value = str(path)
+        if value in sys.path:
+            sys.path.remove(value)
+        sys.path.insert(0, value)
+
+
+_add_package_paths()

--- a/app/library/PackageInstaller.py
+++ b/app/library/PackageInstaller.py
@@ -1,15 +1,23 @@
 import importlib
 import importlib.metadata
+import json
 import os
+import platform
 import subprocess
 import sys
 from pathlib import Path
+
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
 
 from app.library.log import get_logger
 
 from .httpx_client import sync_client
 
 LOG = get_logger()
+
+YTDLP_MASTER_API_URL = "https://api.github.com/repos/yt-dlp/yt-dlp/commits/master"
+YTDLP_MASTER_URL = "https://github.com/yt-dlp/yt-dlp.git"
 
 
 def parse_version(v: str) -> tuple[int, ...]:
@@ -62,18 +70,67 @@ class PackageInstaller:
         if "==" in pkg:
             pkg, version = pkg.split("==", 1)
 
-        current_version: str | None = self._get_installed_version(pkg)
+        if "yt_dlp" == pkg and version and version not in {"master", "nightly"}:
+            try:
+                Version(version)
+            except InvalidVersion as e:
+                msg = f"Invalid yt-dlp version '{version}'; expected 'nightly', 'master', or a valid version."
+                raise ValueError(msg) from e
 
-        if current_version and version and self.compare_versions(current_version, version):
+        current_version: str | None = self._get_installed_version(pkg)
+        target_version: str | None = version
+        latest_revision: str | None = None
+        channel_state = self._get_channel_state() if "yt_dlp" == pkg else None
+        channel_changed = bool(channel_state and version != channel_state.get("channel"))
+
+        if "yt_dlp" == pkg and "nightly" == version:
+            target_version = self._get_latest_version(pkg, prerelease=True)
+            installed_version = channel_state.get("version") if channel_state and not channel_changed else None
+            if installed_version and (not current_version or Version(current_version) != Version(installed_version)):
+                installed_version = None
+            if installed_version and not target_version:
+                LOG.info("Keeping the installed yt-dlp nightly because the latest version could not be determined.")
+                return
+            if installed_version and target_version and Version(installed_version) >= Version(target_version):
+                LOG.info(
+                    "Package '%s' is already installed from the latest nightly channel; skipping installation.",
+                    pkg,
+                    extra={"package": pkg, "installed_version": installed_version, "latest_version": target_version},
+                )
+                return
+        elif "yt_dlp" == pkg and "master" == version:
+            latest_revision = self._get_master_revision()
+            installed_revision = (
+                channel_state.get("revision") if current_version and channel_state and not channel_changed else None
+            )
+            if installed_revision and not latest_revision:
+                LOG.info("Keeping the installed yt-dlp master because the latest revision could not be determined.")
+                return
+            if installed_revision and latest_revision and installed_revision == latest_revision:
+                LOG.info(
+                    "Package '%s' is already installed from the latest master revision; skipping installation.",
+                    pkg,
+                    extra={"package": pkg, "installed_revision": installed_revision},
+                )
+                return
+
+        is_current = bool(
+            current_version
+            and target_version
+            and not channel_changed
+            and version not in {"master", "nightly"}
+            and (self.compare_versions(current_version, target_version))
+        )
+        if is_current:
             LOG.info(
                 "Package '%s' is already installed at version '%s'; skipping installation.",
                 pkg,
-                version,
-                extra={"package": pkg, "installed_version": current_version, "requested_version": version},
+                current_version,
+                extra={"package": pkg, "installed_version": current_version, "requested_version": target_version},
             )
             return
 
-        if upgrade and current_version and not version:
+        if upgrade and current_version and not version and not channel_changed:
             latest_version: str | None = self._get_latest_version(pkg)
             if latest_version and parse_version(current_version) >= parse_version(latest_version):
                 LOG.info(
@@ -94,21 +151,48 @@ class PackageInstaller:
         else:
             LOG.info("Package '%s' is not installed; installing it.", pkg, extra={"package": pkg})
 
-        self._install_pkg(pkg, version=version)
+        installed = self._install_pkg(pkg, version=version)
+        if installed and "yt_dlp" == pkg:
+            if "nightly" == version and target_version:
+                self._set_channel_state({"channel": "nightly", "version": target_version})
+            elif "master" == version and latest_revision:
+                self._set_channel_state({"channel": "master", "revision": latest_revision})
+            else:
+                self._set_channel_state(None)
 
     def _get_installed_version(self, pkg: str) -> str | None:
         try:
-            return importlib.metadata.version(pkg)
+            return self._get_distribution(pkg).version
         except importlib.metadata.PackageNotFoundError:
             return None
 
-    def _get_latest_version(self, pkg: str) -> str | None:
+    def _get_distribution(self, pkg: str) -> importlib.metadata.Distribution:
+        normalized = pkg.lower().replace("_", "-").replace(".", "-")
+        if self.user_site:
+            for distribution in importlib.metadata.distributions(path=[str(self.user_site)]):
+                name = distribution.metadata["Name"].lower().replace("_", "-").replace(".", "-")
+                if normalized == name:
+                    return distribution
+        return importlib.metadata.distribution(pkg)
+
+    def _get_latest_version(self, pkg: str, prerelease: bool = False) -> str | None:
         url: str = f"https://pypi.org/pypi/{pkg}/json"
         try:
             with sync_client(timeout=5.0) as client:
                 resp = client.get(url)
                 if 200 == resp.status_code:
-                    return resp.json()["info"]["version"]
+                    data = resp.json()
+                    if prerelease:
+                        versions: list[tuple[Version, str]] = []
+                        for version, files in data.get("releases", {}).items():
+                            try:
+                                parsed = Version(version)
+                            except InvalidVersion:
+                                continue
+                            if any(self._is_compatible(file) for file in files):
+                                versions.append((parsed, version))
+                        return max(versions)[1] if versions else None
+                    return data["info"]["version"]
                 LOG.warning(
                     "Failed to fetch PyPI metadata for '%s': HTTP %s.",
                     pkg,
@@ -121,6 +205,69 @@ class PackageInstaller:
                 pkg,
                 e,
                 extra={"package": pkg, "url": url, "exception_type": type(e).__name__},
+                exc_info=True,
+            )
+        return None
+
+    def _is_compatible(self, file: dict) -> bool:
+        if file.get("yanked", False):
+            return False
+        requires_python = file.get("requires_python")
+        if not requires_python:
+            return True
+        try:
+            return Version(platform.python_version()) in SpecifierSet(requires_python)
+        except InvalidSpecifier:
+            return False
+
+    def _get_channel_state(self) -> dict[str, str] | None:
+        if not self.user_site:
+            return None
+        try:
+            state = json.loads((self.user_site / ".yt-dlp-channel.json").read_text())
+            if not isinstance(state, dict) or not all(
+                isinstance(key, str) and isinstance(value, str) for key, value in state.items()
+            ):
+                return None
+            return state
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return None
+
+    def _set_channel_state(self, state: dict[str, str] | None) -> None:
+        if not self.user_site:
+            return
+        state_file = self.user_site / ".yt-dlp-channel.json"
+        try:
+            if state:
+                temp_file = state_file.with_suffix(".tmp")
+                temp_file.write_text(json.dumps(state))
+                temp_file.replace(state_file)
+            else:
+                state_file.unlink(missing_ok=True)
+        except OSError as e:
+            LOG.warning(
+                "Failed to persist yt-dlp channel state: %s",
+                e,
+                extra={"state_file": str(state_file), "exception_type": type(e).__name__},
+                exc_info=True,
+            )
+
+    def _get_master_revision(self) -> str | None:
+        try:
+            with sync_client(timeout=5.0) as client:
+                resp = client.get(YTDLP_MASTER_API_URL, headers={"Accept": "application/vnd.github+json"})
+                if 200 == resp.status_code:
+                    return resp.json().get("sha")
+                LOG.warning(
+                    "Failed to fetch yt-dlp master metadata: HTTP %s.",
+                    resp.status_code,
+                    extra={"status_code": resp.status_code, "url": YTDLP_MASTER_API_URL},
+                )
+        except Exception as e:
+            LOG.warning(
+                "Failed to query yt-dlp master metadata: %s",
+                e,
+                extra={"url": YTDLP_MASTER_API_URL, "exception_type": type(e).__name__},
                 exc_info=True,
             )
         return None
@@ -145,7 +292,7 @@ class PackageInstaller:
             if "nightly" == version and "yt-dlp" == pkg:
                 cmd.extend(["--pre", pkg_name])
             elif "master" == version and "yt-dlp" == pkg:
-                cmd.append("git+https://github.com/yt-dlp/yt-dlp.git@master")
+                cmd.append(f"{pkg_name} @ git+{YTDLP_MASTER_URL}@master")
             else:
                 cmd.append(version if str(version).startswith("git+") else f"{pkg_name}=={version}")
         else:

--- a/app/tests/test_app_init.py
+++ b/app/tests/test_app_init.py
@@ -1,0 +1,62 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from app import _add_package_paths
+
+
+def test_adds_package_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    first.mkdir()
+    second.mkdir()
+    config = tmp_path / "config"
+    config.mkdir()
+    monkeypatch.setenv("YTP_CONFIG_PATH", str(config))
+    monkeypatch.setenv("YTP_PYTHON_PATH", os.pathsep.join((str(first), str(second))))
+    monkeypatch.setattr(sys, "path", ["bundled"])
+
+    _add_package_paths()
+
+    user_site = config / f"python{sys.version_info.major}.{sys.version_info.minor}-packages"
+    assert sys.path == [str(first), str(second), str(user_site), "bundled"]
+
+
+def test_ignores_missing_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    existing = tmp_path / "existing"
+    existing.mkdir()
+    monkeypatch.delenv("YTP_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("YTP_PYTHON_PATH", os.pathsep.join((str(tmp_path / "missing"), str(existing))))
+    monkeypatch.setattr(sys, "path", ["bundled"])
+
+    _add_package_paths()
+
+    assert sys.path == [str(existing), "bundled"]
+
+
+def test_moves_existing_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    external = tmp_path / "external"
+    external.mkdir()
+    monkeypatch.delenv("YTP_CONFIG_PATH", raising=False)
+    monkeypatch.setenv("YTP_PYTHON_PATH", str(external))
+    monkeypatch.setattr(sys, "path", ["bundled", str(external)])
+
+    _add_package_paths()
+
+    assert sys.path == [str(external), "bundled"]
+
+
+def test_ignores_package_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = tmp_path / "config"
+    config.mkdir()
+    user_site = config / f"python{sys.version_info.major}.{sys.version_info.minor}-packages"
+    user_site.write_text("not a directory")
+    monkeypatch.setenv("YTP_CONFIG_PATH", str(config))
+    monkeypatch.delenv("YTP_PYTHON_PATH", raising=False)
+    monkeypatch.setattr(sys, "path", ["bundled"])
+
+    _add_package_paths()
+
+    assert sys.path == ["bundled"]

--- a/app/tests/test_package_installer.py
+++ b/app/tests/test_package_installer.py
@@ -8,6 +8,11 @@ import pytest
 from app.library.PackageInstaller import PackageInstaller, Packages, parse_version
 
 
+@pytest.fixture(autouse=True)
+def restore_sys_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "path", sys.path.copy())
+
+
 class TestParseVersion:
     def test_parse_version_basic(self) -> None:
         assert parse_version("1.2.3") == (1, 2, 3)
@@ -81,19 +86,29 @@ class TestVersionCompare:
 
 
 class TestInstalledAndLatest:
-    @patch("app.library.PackageInstaller.importlib.metadata.version")
-    def test_get_installed_version(self, mock_version, tmp_path: Path) -> None:
+    @patch.object(PackageInstaller, "_get_distribution")
+    def test_get_installed_version(self, mock_distribution, tmp_path: Path) -> None:
         inst = PackageInstaller(pkg_path=tmp_path)
-        mock_version.return_value = "1.0.0"
+        mock_distribution.return_value.version = "1.0.0"
         assert inst._get_installed_version("foo") == "1.0.0"
 
-    @patch("app.library.PackageInstaller.importlib.metadata.version")
-    def test_installed_version_not_found(self, mock_version, tmp_path: Path) -> None:
+    @patch.object(PackageInstaller, "_get_distribution")
+    def test_installed_version_not_found(self, mock_distribution, tmp_path: Path) -> None:
         inst = PackageInstaller(pkg_path=tmp_path)
         from importlib.metadata import PackageNotFoundError
 
-        mock_version.side_effect = PackageNotFoundError
+        mock_distribution.side_effect = PackageNotFoundError
         assert inst._get_installed_version("bar") is None
+
+    @patch("app.library.PackageInstaller.importlib.metadata.distributions")
+    def test_distribution_target(self, mock_distributions, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        distribution = MagicMock()
+        distribution.metadata = {"Name": "yt-dlp"}
+        mock_distributions.return_value = [distribution]
+
+        assert inst._get_distribution("yt_dlp") is distribution
+        mock_distributions.assert_called_once_with(path=[str(tmp_path)])
 
     @patch("app.library.PackageInstaller.sync_client")
     def test_get_latest_version_success(self, mock_client, tmp_path: Path) -> None:
@@ -107,6 +122,73 @@ class TestInstalledAndLatest:
         mock_client.return_value.__enter__.return_value = client
 
         assert inst._get_latest_version("foo") == "9.9.9"
+
+    @patch("app.library.PackageInstaller.sync_client")
+    def test_latest_prerelease(self, mock_client, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        client = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "info": {"version": "2025.6.1"},
+            "releases": {
+                "2025.5.1.1.dev0": [{"yanked": False}],
+                "2025.6.2.2.dev0": [{"yanked": False}],
+                "2025.6.3.3.dev0": [{"yanked": True}],
+                "2025.6.4": [{"yanked": False}],
+                "2025.6.5": [{"yanked": False, "requires_python": ">=99"}],
+            },
+        }
+        client.get.return_value = resp
+        mock_client.return_value.__enter__.return_value = client
+
+        assert inst._get_latest_version("yt_dlp", prerelease=True) == "2025.6.4"
+
+    @patch("app.library.PackageInstaller.sync_client")
+    def test_prerelease_missing(self, mock_client, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        client = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"info": {"version": "2025.6.1"}, "releases": {}}
+        client.get.return_value = resp
+        mock_client.return_value.__enter__.return_value = client
+
+        assert inst._get_latest_version("yt_dlp", prerelease=True) is None
+
+    def test_channel_state(self, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        state = {"channel": "master", "revision": "abc123"}
+
+        inst._set_channel_state(state)
+
+        assert inst._get_channel_state() == state
+
+    def test_state_malformed(self, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        (tmp_path / ".yt-dlp-channel.json").write_text("not-json")
+
+        assert inst._get_channel_state() is None
+
+    def test_state_removed(self, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        inst._set_channel_state({"channel": "nightly", "version": "2025.6.4"})
+
+        inst._set_channel_state(None)
+
+        assert inst._get_channel_state() is None
+
+    @patch("app.library.PackageInstaller.sync_client")
+    def test_master_revision(self, mock_client, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        client = MagicMock()
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"sha": "abc123"}
+        client.get.return_value = resp
+        mock_client.return_value.__enter__.return_value = client
+
+        assert inst._get_master_revision() == "abc123"
 
     @patch("app.library.PackageInstaller.sync_client")
     def test_latest_version_non_200(self, mock_client, tmp_path: Path) -> None:
@@ -182,7 +264,7 @@ class TestInstallCmd:
         ok = inst._install_pkg("yt_dlp", version="master")
         assert ok is True
         cmd = mock_run.call_args.args[0]
-        assert "git+https://github.com/yt-dlp/yt-dlp.git@master" in cmd
+        assert "yt-dlp[default] @ git+https://github.com/yt-dlp/yt-dlp.git@master" in cmd
 
     @patch("app.library.PackageInstaller.subprocess.run")
     def test_install_called_process_error(self, mock_run, tmp_path: Path) -> None:
@@ -204,6 +286,15 @@ class TestInstallCmd:
 
 
 class TestActionAndCheck:
+    @patch.object(PackageInstaller, "_install_pkg")
+    def test_ytdlp_invalid(self, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+
+        with pytest.raises(ValueError, match="Invalid yt-dlp version 'nighly'"):
+            inst.action("yt_dlp==nighly", upgrade=True)
+
+        mock_install.assert_not_called()
+
     @patch.object(PackageInstaller, "_install_pkg")
     @patch.object(PackageInstaller, "_get_installed_version")
     def test_action_skip_pinned(self, mock_get_installed, mock_install, tmp_path: Path) -> None:
@@ -240,6 +331,162 @@ class TestActionAndCheck:
         mock_get_installed.return_value = None
         inst.action("pkg")
         mock_install.assert_called_once_with("pkg", version=None)
+
+    @patch.object(PackageInstaller, "_install_pkg")
+    @patch.object(PackageInstaller, "_get_channel_state")
+    @patch.object(PackageInstaller, "_get_latest_version")
+    @patch.object(PackageInstaller, "_get_installed_version")
+    def test_nightly_current(self, mock_installed, mock_latest, mock_state, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        mock_installed.return_value = "2025.6.2.2.dev0"
+        mock_latest.return_value = "2025.6.2.2.dev0"
+        mock_state.return_value = {"channel": "nightly", "version": "2025.6.2.2.dev0"}
+
+        inst.action("yt_dlp==nightly", upgrade=True)
+
+        mock_latest.assert_called_once_with("yt_dlp", prerelease=True)
+        mock_install.assert_not_called()
+
+    @patch.object(PackageInstaller, "_install_pkg")
+    @patch.object(PackageInstaller, "_get_channel_state")
+    @patch.object(PackageInstaller, "_get_latest_version")
+    @patch.object(PackageInstaller, "_get_installed_version")
+    def test_nightly_newer(self, mock_installed, mock_latest, mock_state, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        mock_installed.return_value = "2025.6.3.3.dev0"
+        mock_latest.return_value = "2025.6.2.2.dev0"
+        mock_state.return_value = {"channel": "nightly", "version": "2025.6.3.3.dev0"}
+
+        inst.action("yt_dlp==nightly", upgrade=True)
+
+        mock_install.assert_not_called()
+
+    @patch.object(PackageInstaller, "_install_pkg")
+    @patch.object(PackageInstaller, "_get_latest_version")
+    @patch.object(PackageInstaller, "_get_installed_version")
+    def test_nightly_outdated(self, mock_installed, mock_latest, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        mock_installed.return_value = "2025.6.1.1.dev0"
+        mock_latest.return_value = "2025.6.2.2.dev0"
+
+        inst.action("yt_dlp==nightly", upgrade=True)
+
+        mock_install.assert_called_once_with("yt_dlp", version="nightly")
+
+    @patch.object(PackageInstaller, "_install_pkg")
+    @patch.object(PackageInstaller, "_get_latest_version")
+    @patch.object(PackageInstaller, "_get_installed_version")
+    def test_nightly_lookup_fails(self, mock_installed, mock_latest, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        mock_installed.return_value = "2025.6.1.1.dev0"
+        mock_latest.return_value = None
+
+        inst.action("yt_dlp==nightly", upgrade=True)
+
+        mock_install.assert_called_once_with("yt_dlp", version="nightly")
+
+    @patch.object(PackageInstaller, "_install_pkg")
+    @patch.object(PackageInstaller, "_get_channel_state")
+    @patch.object(PackageInstaller, "_get_latest_version")
+    @patch.object(PackageInstaller, "_get_installed_version")
+    def test_nightly_lookup_keeps(self, mock_installed, mock_latest, mock_state, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        mock_installed.return_value = "2025.6.1.1.dev0"
+        mock_latest.return_value = None
+        mock_state.return_value = {"channel": "nightly", "version": "2025.6.1.1.dev0"}
+
+        inst.action("yt_dlp==nightly", upgrade=True)
+
+        mock_install.assert_not_called()
+
+    @patch.object(PackageInstaller, "_install_pkg", return_value=True)
+    @patch.object(
+        PackageInstaller, "_get_channel_state", return_value={"channel": "nightly", "version": "2025.6.2.2.dev0"}
+    )
+    @patch.object(PackageInstaller, "_get_latest_version", return_value="2025.6.2.2.dev0")
+    @patch.object(PackageInstaller, "_get_installed_version", return_value=None)
+    def test_nightly_missing(self, _mock_version, _mock_latest, _mock_state, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+
+        inst.action("yt_dlp==nightly", upgrade=True)
+
+        mock_install.assert_called_once_with("yt_dlp", version="nightly")
+
+    @patch.object(PackageInstaller, "_install_pkg", return_value=True)
+    @patch.object(PackageInstaller, "_get_latest_version", return_value="2025.6.2.2.dev0")
+    @patch.object(PackageInstaller, "_get_installed_version")
+    def test_nightly_restart(self, _mock_version, _mock_latest, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        _mock_version.side_effect = ["2025.6.1", "2025.6.2.2.dev0"]
+
+        inst.action("yt_dlp==nightly", upgrade=True)
+        inst.action("yt_dlp==nightly", upgrade=True)
+
+        mock_install.assert_called_once_with("yt_dlp", version="nightly")
+
+    @patch.object(PackageInstaller, "_install_pkg")
+    @patch.object(PackageInstaller, "_get_master_revision")
+    @patch.object(PackageInstaller, "_get_channel_state")
+    @patch.object(PackageInstaller, "_get_installed_version")
+    def test_master_current(self, mock_version, mock_installed, mock_latest, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        mock_version.return_value = "2025.6.1"
+        mock_installed.return_value = {"channel": "master", "revision": "abc123"}
+        mock_latest.return_value = "abc123"
+
+        inst.action("yt_dlp==master", upgrade=True)
+
+        mock_install.assert_not_called()
+
+    @patch.object(PackageInstaller, "_install_pkg")
+    @patch.object(PackageInstaller, "_get_master_revision")
+    @patch.object(PackageInstaller, "_get_channel_state")
+    @patch.object(PackageInstaller, "_get_installed_version")
+    def test_master_outdated(self, mock_version, mock_installed, mock_latest, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        mock_version.return_value = "2025.6.1"
+        mock_installed.return_value = {"channel": "master", "revision": "abc123"}
+        mock_latest.return_value = "def456"
+
+        inst.action("yt_dlp==master", upgrade=True)
+
+        mock_install.assert_called_once_with("yt_dlp", version="master")
+
+    @patch.object(PackageInstaller, "_install_pkg")
+    @patch.object(PackageInstaller, "_get_master_revision")
+    @patch.object(PackageInstaller, "_get_channel_state")
+    @patch.object(PackageInstaller, "_get_installed_version")
+    def test_master_lookup_fails(self, mock_version, mock_installed, mock_latest, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+        mock_version.return_value = "2025.6.1"
+        mock_installed.return_value = {"channel": "master", "revision": "abc123"}
+        mock_latest.return_value = None
+
+        inst.action("yt_dlp==master", upgrade=True)
+
+        mock_install.assert_not_called()
+
+    @patch.object(PackageInstaller, "_install_pkg", return_value=True)
+    @patch.object(PackageInstaller, "_get_master_revision", return_value="abc123")
+    @patch.object(PackageInstaller, "_get_channel_state", return_value={"channel": "master", "revision": "abc123"})
+    @patch.object(PackageInstaller, "_get_installed_version", return_value=None)
+    def test_master_missing(self, _mock_version, _mock_state, _mock_latest, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+
+        inst.action("yt_dlp==master", upgrade=True)
+
+        mock_install.assert_called_once_with("yt_dlp", version="master")
+
+    @patch.object(PackageInstaller, "_install_pkg", return_value=True)
+    @patch.object(PackageInstaller, "_get_master_revision", return_value="abc123")
+    @patch.object(PackageInstaller, "_get_installed_version", return_value="2025.6.1")
+    def test_master_restart(self, _mock_version, _mock_latest, mock_install, tmp_path: Path) -> None:
+        inst = PackageInstaller(pkg_path=tmp_path)
+
+        inst.action("yt_dlp==master", upgrade=True)
+        inst.action("yt_dlp==master", upgrade=True)
+
+        mock_install.assert_called_once_with("yt_dlp", version="master")
 
     @patch.object(PackageInstaller, "action")
     def test_check_runs_all(self, mock_action, tmp_path: Path) -> None:

--- a/ui/modules/icon-catalog.ts
+++ b/ui/modules/icon-catalog.ts
@@ -53,6 +53,16 @@ export const writeCatalogIfChanged = async (path: string, content: string): Prom
   return true;
 };
 
+export const extractIcons = (
+  scanner: IconUsageScanner,
+  code: string,
+  icons: Set<string>,
+): boolean => {
+  const count = icons.size;
+  scanner.extractFromCode(code, icons);
+  return icons.size !== count;
+};
+
 export default defineNuxtModule({
   meta: { name: 'ytptube-icon-catalog' },
   setup(_options, nuxt) {
@@ -64,6 +74,9 @@ export default defineNuxtModule({
     let catalogChanged = false;
 
     nuxt.hook('icon:clientBundleIcons', async (icons) => {
+      for (const icon of icons) {
+        incrementalIcons.add(icon);
+      }
       for (const icon of incrementalIcons) {
         icons.add(icon);
       }
@@ -98,6 +111,7 @@ export default defineNuxtModule({
               catalogChanged = false;
               const destinations = new Set<string>();
               try {
+                let iconsChanged = false;
                 if (scanner) {
                   const sourcePaths = [...pendingSourcePaths];
                   pendingSourcePaths.clear();
@@ -111,9 +125,13 @@ export default defineNuxtModule({
                           throw error;
                         },
                       );
-                      scanner.extractFromCode(code, incrementalIcons);
+                      iconsChanged = extractIcons(scanner, code, incrementalIcons) || iconsChanged;
                     }),
                   );
+                }
+
+                if (!iconsChanged) {
+                  continue;
                 }
 
                 await updateTemplates({

--- a/ui/tests/modules/icon-catalog.test.ts
+++ b/ui/tests/modules/icon-catalog.test.ts
@@ -3,7 +3,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { expect, test } from 'bun:test';
 import { IconUsageScanner } from '@nuxt/icon/utils';
-import { isRelevantSource, renderCatalog, writeCatalogIfChanged } from '../../modules/icon-catalog';
+import {
+  extractIcons,
+  isRelevantSource,
+  renderCatalog,
+  writeCatalogIfChanged,
+} from '../../modules/icon-catalog';
 
 test('test source filtering', () => {
   const root = '/workspace/ui';
@@ -22,11 +27,12 @@ test('test catalog rendering', () => {
 
 test('test incremental extraction', () => {
   const scanner = new IconUsageScanner({ globInclude: ['app/**/*.{vue,ts,js}'] });
-  const icons = new Set<string>();
+  const icons = new Set(['lucide:activity']);
 
-  scanner.extractFromCode('<Icon name="i-lucide-alarm-clock-minus" />', icons);
+  expect(extractIcons(scanner, '<Icon name="i-lucide-activity" />', icons)).toBe(false);
+  expect(extractIcons(scanner, '<Icon name="i-lucide-alarm-clock-minus" />', icons)).toBe(true);
 
-  expect(icons).toEqual(new Set(['lucide:alarm-clock-minus']));
+  expect(icons).toEqual(new Set(['lucide:activity', 'lucide:alarm-clock-minus']));
 });
 
 test('test unchanged catalog', async () => {


### PR DESCRIPTION
- Updated the documentation to describe the new `YTP_PYTHON_PATH` variable and provide instructions for manually updating `yt-dlp` in native executables.
- Refactored `PackageInstaller.py` to support installation and persistent tracking of `yt-dlp` from stable, nightly, and master channels. The installer now checks if the requested channel/version is already installed and persists the state in `.yt-dlp-channel.json`.
- Improved version and revision detection for nightly and master channels, including compatibility checks for pre-releases and Python version requirements.

